### PR TITLE
Refine upload pipeline validation and cleanup

### DIFF
--- a/__tests__/api/uploadDocument/uploadDocument.test.ts
+++ b/__tests__/api/uploadDocument/uploadDocument.test.ts
@@ -1,0 +1,231 @@
+import { POST } from "~/app/api/uploadDocument/route";
+import { validateRequestBody } from "~/lib/validation";
+import { db } from "~/server/db/index";
+
+jest.mock("~/lib/validation", () => {
+  const actual = jest.requireActual("~/lib/validation");
+  return {
+    ...actual,
+    validateRequestBody: jest.fn(),
+  };
+});
+
+jest.mock("~/server/db/index", () => ({
+  db: {
+    select: jest.fn(),
+    transaction: jest.fn(),
+  },
+}));
+
+const mockFetch = jest.fn();
+
+jest.mock("node-fetch", () => ({
+  __esModule: true,
+  default: (...args: unknown[]) => mockFetch(...args),
+}));
+
+const mockWriteFile = jest.fn();
+const mockUnlink = jest.fn();
+
+jest.mock("fs/promises", () => ({
+  writeFile: (...args: unknown[]) => mockWriteFile(...args),
+  unlink: (...args: unknown[]) => mockUnlink(...args),
+}));
+
+const mockLoad = jest.fn();
+jest.mock("@langchain/community/document_loaders/fs/pdf", () => ({
+  PDFLoader: jest.fn().mockImplementation(() => ({
+    load: (...args: unknown[]) => mockLoad(...args),
+  })),
+}));
+
+const mockSplitDocuments = jest.fn();
+jest.mock("@langchain/textsplitters", () => ({
+  RecursiveCharacterTextSplitter: jest.fn().mockImplementation(() => ({
+    splitDocuments: (...args: unknown[]) => mockSplitDocuments(...args),
+  })),
+}));
+
+const mockEmbedDocuments = jest.fn();
+jest.mock("@langchain/openai", () => ({
+  OpenAIEmbeddings: jest.fn().mockImplementation(() => ({
+    embedDocuments: (...args: unknown[]) => mockEmbedDocuments(...args),
+  })),
+}));
+
+describe("POST /api/uploadDocument", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockWriteFile.mockReset();
+    mockUnlink.mockReset();
+    mockLoad.mockReset();
+    mockSplitDocuments.mockReset();
+    mockEmbedDocuments.mockReset();
+    mockFetch.mockReset();
+    mockWriteFile.mockImplementation(async () => undefined);
+    mockUnlink.mockImplementation(async () => undefined);
+    process.env.OPENAI_API_KEY = "test-key";
+  });
+
+  it("uploads and processes a document successfully", async () => {
+    (validateRequestBody as jest.Mock).mockResolvedValue({
+      success: true,
+      data: {
+        userId: "user-1",
+        documentName: "Example Document ",
+        documentUrl: "https://example.com/doc.pdf",
+        documentCategory: "contracts",
+      },
+    });
+
+    const mockWhere = jest.fn().mockResolvedValue([
+      { userId: "user-1", companyId: "5" },
+    ]);
+
+    const mockFrom = jest.fn().mockReturnValue({ where: mockWhere });
+    (db.select as jest.Mock).mockReturnValue({ from: mockFrom });
+
+    const pdfBuffer = Buffer.from("%PDF test content");
+    mockFetch.mockResolvedValue({
+      ok: true,
+      arrayBuffer: async () => pdfBuffer,
+    });
+
+    mockLoad.mockResolvedValue([
+      { pageContent: "Full content", metadata: { loc: { pageNumber: 2 } } },
+    ]);
+
+    mockSplitDocuments.mockResolvedValue([
+      { pageContent: "Chunk content", metadata: { loc: { pageNumber: 2 } } },
+    ]);
+
+    mockEmbedDocuments.mockResolvedValue([[0.1, 0.2, 0.3]]);
+
+    const insertedDocument = {
+      id: 42,
+      url: "https://example.com/doc.pdf",
+      category: "contracts",
+      title: "Example Document",
+      companyId: "5",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+
+    (db.transaction as jest.Mock).mockImplementation(async (callback: (tx: unknown) => Promise<void>) => {
+      const insertDocumentValues = jest.fn().mockReturnValue({
+        returning: jest.fn().mockResolvedValue([insertedDocument]),
+      });
+
+      const insertChunksValues = jest.fn().mockResolvedValue(undefined);
+
+      const tx = {
+        insert: jest
+          .fn()
+          .mockReturnValueOnce({ values: insertDocumentValues })
+          .mockReturnValueOnce({ values: insertChunksValues }),
+      };
+
+      await callback(tx);
+    });
+
+    const request = new Request("http://localhost/api/uploadDocument", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({}),
+    });
+
+    const response = await POST(request);
+    const json = await response.json();
+
+    expect(response.status).toBe(201);
+    expect(json.document).toMatchObject({
+      id: insertedDocument.id,
+      url: insertedDocument.url,
+      category: insertedDocument.category,
+      title: insertedDocument.title,
+      companyId: insertedDocument.companyId,
+    });
+    expect(mockWriteFile).toHaveBeenCalledTimes(1);
+    expect(mockUnlink).toHaveBeenCalledTimes(1);
+    expect(mockUnlink.mock.calls[0][0]).toContain("pdr-ai-upload-");
+    expect(db.transaction).toHaveBeenCalledTimes(1);
+  });
+
+  it("cleans up temporary file when processing fails", async () => {
+    (validateRequestBody as jest.Mock).mockResolvedValue({
+      success: true,
+      data: {
+        userId: "user-2",
+        documentName: "Broken Document",
+        documentUrl: "https://example.com/broken.pdf",
+        documentCategory: "finance",
+      },
+    });
+
+    const mockWhere = jest.fn().mockResolvedValue([
+      { userId: "user-2", companyId: "7" },
+    ]);
+
+    const mockFrom = jest.fn().mockReturnValue({ where: mockWhere });
+    (db.select as jest.Mock).mockReturnValue({ from: mockFrom });
+
+    const pdfBuffer = Buffer.from("%PDF test content");
+    mockFetch.mockResolvedValue({
+      ok: true,
+      arrayBuffer: async () => pdfBuffer,
+    });
+
+    mockLoad.mockResolvedValue([
+      { pageContent: "Full content", metadata: { loc: { pageNumber: 1 } } },
+    ]);
+
+    mockSplitDocuments.mockResolvedValue([
+      { pageContent: "Chunk content", metadata: { loc: { pageNumber: 1 } } },
+    ]);
+
+    mockEmbedDocuments.mockResolvedValue([[0.1, 0.2]]);
+
+    (db.transaction as jest.Mock).mockImplementation(async () => {
+      throw new Error("transaction failed");
+    });
+
+    const request = new Request("http://localhost/api/uploadDocument", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({}),
+    });
+
+    const response = await POST(request);
+    await response.json();
+
+    expect(response.status).toBe(500);
+    expect(mockUnlink).toHaveBeenCalledTimes(1);
+    expect(mockUnlink.mock.calls[0][0]).toContain("pdr-ai-upload-");
+  });
+
+  it("returns validation response when request body is invalid", async () => {
+    const validationResponse = new Response(
+      JSON.stringify({ error: "Invalid request" }),
+      { status: 400 },
+    );
+
+    (validateRequestBody as jest.Mock).mockResolvedValue({
+      success: false,
+      response: validationResponse,
+    });
+
+    const request = new Request("http://localhost/api/uploadDocument", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({}),
+    });
+
+    const response = await POST(request);
+    const json = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(json).toEqual({ error: "Invalid request" });
+    expect(db.select).not.toHaveBeenCalled();
+    expect(mockWriteFile).not.toHaveBeenCalled();
+  });
+});

--- a/docs/pr-ideas.md
+++ b/docs/pr-ideas.md
@@ -1,0 +1,35 @@
+# PR Roadmap Ideas
+
+## 1. Secure Company Settings Update API
+- **Problem**: `/api/updateCompany` accepts a `userId` from the client, trusts it without verifying the session, and updates company settings without confirming role or company ownership.
+- **Scope**:
+  - Switch to `auth()` within the handler to derive the authenticated user and reject unauthenticated calls.
+  - Rework validation with `validateRequestBody` + a new schema that only covers mutable fields (name, passkeys, staff count).
+  - Look up the user via Clerk ID, ensure their role is `employer`/`owner`, and that they belong to the target company; return 403 otherwise.
+  - Update the frontend (`src/app/employer/settings/page.tsx:154`) to stop sending `userId` and handle new error shapes.
+  - Expand Jest coverage to include: unauthenticated, unauthorized role, mismatched company, and successful update.
+- **Acceptance**: API no longer trusts client-provided identifiers, rejects cross-company attempts, and tests document the new behaviour.
+
+## 2. Harden Employee Approval & Removal APIs
+- **Problem**: `/api/approveEmployees` and `/api/removeEmployees` trust the incoming `employeeId` and only check caller role; they can mutate users in other companies, accept non-numeric input, and return vague errors.
+- **Scope**:
+  - Add Zod schemas (`ApproveEmployeeSchema` updates) to require numeric IDs and descriptive error responses.
+  - Within each handler, pull the target employee, verify they belong to the caller’s company, and short-circuit if they are already in the desired state (e.g., already verified).
+  - Provide differentiated messages for missing employee, cross-company access, and invalid role.
+  - Extend Jest suites under `__tests__/api` to cover success, invalid payload, employee not found, cross-company access, and duplicate approvals.
+- **Acceptance**: Both endpoints block cross-tenant mutations, give actionable errors, and maintain parity with updated tests.
+
+## 3. Document Upload Telemetry & Rate Guardrails
+- Add server-side logging around `/api/uploadDocument` to capture PDF size, processing duration, and OpenAI latency (without storing file contents). Emit aggregated metrics for slow uploads and retries.
+- Introduce rate limiting (e.g., per user/company via Upstash or in-memory p-limit) to prevent accidental DoS from rapid uploads.
+- Extend tests to assert guardrails trigger when exceeding thresholds and ensure logs are emitted on critical branches.
+
+## 4. Predictive Analysis Cache Diagnostics
+- Surface cache hits vs misses from `/api/predictive-document-analysis` in the employer dashboard UI to make the 24h TTL observable.
+- Add an API query parameter to return cache freshness metadata, and create a lightweight UI indicator on `src/app/employer/documents/page.tsx`.
+- Cover UI state with component tests (mocking fetch) and an API unit test for cache-enabled responses.
+
+## 5. Structured Error Responses for AI Endpoints
+- Standardize error envelopes (`{ success, message, code }`) across `/api/AIAssistant`, `/api/predictive-document-analysis`, and `/api/LangChain`.
+- Replace `console.error` with structured logger hooks that tag request IDs and user IDs (when available) to simplify tracing.
+- Update front-end fetch consumers to handle the new envelope and show actionable toasts; backfill Jest tests to assert codes and messages.

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -93,6 +93,13 @@ export const ApproveEmployeeSchema = z.object({
   companyId: z.string().min(1, "Company ID is required"),
 });
 
+export const UploadDocumentSchema = z.object({
+  userId: z.string().min(1, "User ID is required").max(256, "User ID is too long").trim(),
+  documentName: z.string().min(1, "Document name is required").max(256, "Document name is too long").trim(),
+  documentUrl: z.string().url("Document URL must be a valid URL").max(2048, "Document URL is too long").trim(),
+  documentCategory: z.string().min(1, "Document category is required").max(256, "Document category is too long").trim(),
+});
+
 export const EmployeeAuthSchema = z.object({
   userId: z.string().min(1, "User ID is required"),
   companyPasskey: z.string().min(1, "Company passkey is required"),


### PR DESCRIPTION
## Summary
- validate uploadDocument input with a shared schema and remove reliance on client-supplied IDs
- wrap document + chunk creation in a single transaction and clean up temp files to avoid partial writes
- improve error messaging around download and embedding failures
- add focused Jest coverage for the upload route

## Testing
- pnpm test __tests__/api/uploadDocument/uploadDocument.test.ts