### PR TITLE
Secure employer company update flow

### DIFF
--- a/__tests__/api/updateCompany/updateCompany.test.ts
+++ b/__tests__/api/updateCompany/updateCompany.test.ts
@@ -1,0 +1,173 @@
+import { POST } from "~/app/api/updateCompany/route";
+import { auth } from "@clerk/nextjs/server";
+import { validateRequestBody } from "~/lib/validation";
+import { db } from "~/server/db/index";
+
+jest.mock("@clerk/nextjs/server", () => ({
+  auth: jest.fn(),
+}));
+
+jest.mock("~/lib/validation", () => {
+  const actual = jest.requireActual("~/lib/validation");
+  return {
+    ...actual,
+    validateRequestBody: jest.fn(),
+  };
+});
+
+jest.mock("~/server/db/index", () => ({
+  db: {
+    select: jest.fn(),
+    update: jest.fn(),
+  },
+}));
+
+describe("POST /api/updateCompany", () => {
+  const makeRequest = (body: unknown) =>
+    new Request("http://localhost/api/updateCompany", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("updates company settings for authorized employer", async () => {
+    (auth as jest.Mock).mockResolvedValue({ userId: "user-123" });
+    (validateRequestBody as jest.Mock).mockResolvedValue({
+      success: true,
+      data: {
+        name: "Acme Corp",
+        employerPasskey: "EMP123",
+        employeePasskey: "EMP456",
+        numberOfEmployees: "25",
+      },
+    });
+
+    const mockWhereSelect = jest.fn().mockResolvedValue([
+      { id: 1, companyId: "7", role: "employer" },
+    ]);
+    const mockFrom = jest.fn().mockReturnValue({ where: mockWhereSelect });
+    (db.select as jest.Mock).mockReturnValue({ from: mockFrom });
+
+    const mockReturning = jest.fn().mockResolvedValue([{ id: 7 }]);
+    const mockWhereUpdate = jest.fn().mockReturnValue({ returning: mockReturning });
+    const mockSet = jest.fn().mockReturnValue({ where: mockWhereUpdate });
+    (db.update as jest.Mock).mockReturnValue({ set: mockSet });
+
+    const response = await POST(makeRequest({}));
+    const json = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(json).toEqual({
+      success: true,
+      message: "Company settings updated.",
+    });
+    expect(mockSet).toHaveBeenCalledWith({
+      name: "Acme Corp",
+      employerpasskey: "EMP123",
+      employeepasskey: "EMP456",
+      numberOfEmployees: "25",
+    });
+    expect(mockWhereUpdate).toHaveBeenCalled();
+  });
+
+  it("returns 401 when user is not authenticated", async () => {
+    (auth as jest.Mock).mockResolvedValue({ userId: null });
+
+    const response = await POST(makeRequest({}));
+    const json = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(json).toEqual({
+      success: false,
+      message: "Unauthorized",
+    });
+    expect(validateRequestBody).not.toHaveBeenCalled();
+  });
+
+  it("returns 403 when user lacks employer privileges", async () => {
+    (auth as jest.Mock).mockResolvedValue({ userId: "user-123" });
+    (validateRequestBody as jest.Mock).mockResolvedValue({
+      success: true,
+      data: {
+        name: "Acme Corp",
+        employerPasskey: "EMP123",
+        employeePasskey: "EMP456",
+        numberOfEmployees: "10",
+      },
+    });
+
+    const mockWhereSelect = jest.fn().mockResolvedValue([
+      { id: 1, companyId: "7", role: "employee" },
+    ]);
+    const mockFrom = jest.fn().mockReturnValue({ where: mockWhereSelect });
+    (db.select as jest.Mock).mockReturnValue({ from: mockFrom });
+
+    const response = await POST(makeRequest({}));
+    const json = await response.json();
+
+    expect(response.status).toBe(403);
+    expect(json).toEqual({
+      success: false,
+      message: "Forbidden",
+    });
+    expect(db.update).not.toHaveBeenCalled();
+  });
+
+  it("bubbles validation failure response", async () => {
+    (auth as jest.Mock).mockResolvedValue({ userId: "user-123" });
+
+    const validationResponse = new Response(
+      JSON.stringify({ success: false, message: "Invalid payload" }),
+      { status: 400 }
+    );
+
+    (validateRequestBody as jest.Mock).mockResolvedValue({
+      success: false,
+      response: validationResponse,
+    });
+
+    const response = await POST(makeRequest({}));
+    const json = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(json).toEqual({ success: false, message: "Invalid payload" });
+    expect(db.select).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 when company record is missing", async () => {
+    (auth as jest.Mock).mockResolvedValue({ userId: "user-123" });
+    (validateRequestBody as jest.Mock).mockResolvedValue({
+      success: true,
+      data: {
+        name: "Acme Corp",
+        employerPasskey: "EMP123",
+        employeePasskey: "EMP456",
+        numberOfEmployees: "15",
+      },
+    });
+
+    const mockWhereSelect = jest.fn().mockResolvedValue([
+      { id: 1, companyId: "7", role: "owner" },
+    ]);
+    const mockFrom = jest.fn().mockReturnValue({ where: mockWhereSelect });
+    (db.select as jest.Mock).mockReturnValue({ from: mockFrom });
+
+    const mockReturning = jest.fn().mockResolvedValue([]);
+    const mockWhereUpdate = jest.fn().mockReturnValue({ returning: mockReturning });
+    const mockSet = jest.fn().mockReturnValue({ where: mockWhereUpdate });
+    (db.update as jest.Mock).mockReturnValue({ set: mockSet });
+
+    const response = await POST(makeRequest({}));
+    const json = await response.json();
+
+    expect(response.status).toBe(404);
+    expect(json).toEqual({
+      success: false,
+      message: "Unable to update company record.",
+    });
+  });
+});

--- a/src/app/api/updateCompany/route.ts
+++ b/src/app/api/updateCompany/route.ts
@@ -1,54 +1,98 @@
 import { NextResponse } from "next/server";
+import { eq } from "drizzle-orm";
+import { auth } from "@clerk/nextjs/server";
+
 import { db } from "../../../server/db/index";
 import { company, users } from "../../../server/db/schema";
-import { eq } from "drizzle-orm";
-import * as console from "console";
+import { validateRequestBody, UpdateCompanySchema } from "~/lib/validation";
 
-type PostBody = {
-    userId: string;
-    name: string;
-    employerPasskey: string;
-    employeePasskey: string;
-    numberOfEmployees: string;
-}
-
+const AUTHORIZED_ROLES = new Set(["employer", "owner"]);
 
 export async function POST(request: Request) {
-    try {
-        const { userId, name, employerPasskey, employeePasskey, numberOfEmployees  } = (await request.json()) as PostBody;
+  try {
+    const { userId } = await auth();
 
-        const [userInfo] = await db
-            .select()
-            .from(users)
-            .where(eq(users.userId, userId));
-
-        if (!userInfo) {
-            return NextResponse.json(
-                { error: "Invalid user." },
-                { status: 400 }
-            );
-        }
-
-        const companyId = userInfo.companyId;
-
-        await db //update company
-            .update(company)
-            .set({
-                name: name,
-                employerpasskey: employerPasskey,
-                employeepasskey: employeePasskey,
-                numberOfEmployees: numberOfEmployees ?? '0',
-            })
-            .where(eq(company.id, Number(companyId)))
-            .returning({ id: company.id });
-
-        // Return as JSON
-        return NextResponse.json( { status: 200 });
-    } catch (error: unknown) {
-        console.error("Error fetching documents:", error);
-        return NextResponse.json(
-            { error: "Unable to fetch documents" },
-            { status: 500 }
-        );
+    if (!userId) {
+      return NextResponse.json(
+        {
+          success: false,
+          message: "Unauthorized",
+        },
+        { status: 401 }
+      );
     }
+
+    const validation = await validateRequestBody(request, UpdateCompanySchema);
+    if (!validation.success) {
+      return validation.response;
+    }
+    const { name, employerPasskey, employeePasskey, numberOfEmployees } = validation.data;
+
+    const [userRecord] = await db
+      .select({
+        id: users.id,
+        companyId: users.companyId,
+        role: users.role,
+      })
+      .from(users)
+      .where(eq(users.userId, userId));
+
+    if (!userRecord) {
+      return NextResponse.json(
+        {
+          success: false,
+          message: "Unauthorized",
+        },
+        { status: 401 }
+      );
+    }
+
+    if (!AUTHORIZED_ROLES.has(userRecord.role)) {
+      return NextResponse.json(
+        {
+          success: false,
+          message: "Forbidden",
+        },
+        { status: 403 }
+      );
+    }
+
+    const updateResult = await db
+      .update(company)
+      .set({
+        name,
+        employerpasskey: employerPasskey,
+        employeepasskey: employeePasskey,
+        numberOfEmployees,
+      })
+      .where(eq(company.id, Number(userRecord.companyId)))
+      .returning({ id: company.id });
+
+    if (!updateResult || updateResult.length === 0) {
+      return NextResponse.json(
+        {
+          success: false,
+          message: "Unable to update company record.",
+        },
+        { status: 404 }
+      );
+    }
+
+    return NextResponse.json(
+      {
+        success: true,
+        message: "Company settings updated.",
+      },
+      { status: 200 }
+    );
+  } catch (error) {
+    console.error("Error updating company settings:", error);
+    return NextResponse.json(
+      {
+        success: false,
+        message: "Unable to update company settings.",
+      },
+      { status: 500 }
+    );
+  }
 }

--- a/src/app/employer/settings/page.tsx
+++ b/src/app/employer/settings/page.tsx
@@ -155,7 +155,6 @@ const SettingsPage = () => {
                 method: "POST",
                 headers: { "Content-Type": "application/json" },
                 body: JSON.stringify({
-                    userId,
                     name: companyName,
                     employerPasskey,
                     employeePasskey,
@@ -163,14 +162,18 @@ const SettingsPage = () => {
                 }),
             });
 
-            if (!response.ok) {
-                throw new Error("Error updating settings");
+            const result: { success?: boolean; message?: string } | null = await response
+                .json()
+                .catch(() => null);
+
+            if (!response.ok || result?.success !== true) {
+                throw new Error(result?.message ?? "Error updating settings");
             }
 
-            showPopup("Company settings saved!");
+            showPopup(result?.message ?? "Company settings saved!");
         } catch (error) {
             console.error(error);
-            showPopup("Failed to update settings. Please try again.");
+            showPopup(error instanceof Error ? error.message : "Failed to update settings. Please try again.");
         } finally {
             setIsSaving(false);
         }

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -100,6 +100,23 @@ export const UploadDocumentSchema = z.object({
   documentCategory: z.string().min(1, "Document category is required").max(256, "Document category is too long").trim(),
 });
 
+export const UpdateCompanySchema = z.object({
+  name: z.string().min(1, "Company name is required").max(256, "Company name is too long").trim(),
+  employerPasskey: z.string().min(1, "Employer passkey is required").max(256, "Employer passkey is too long").trim(),
+  employeePasskey: z.string().min(1, "Employee passkey is required").max(256, "Employee passkey is too long").trim(),
+  numberOfEmployees: z
+    .string()
+    .trim()
+    .regex(/^\d*$/, "Number of employees must contain only digits")
+    .max(9, "Number of employees is too long")
+    .optional(),
+}).transform((data) => ({
+  name: data.name,
+  employerPasskey: data.employerPasskey,
+  employeePasskey: data.employeePasskey,
+  numberOfEmployees: data.numberOfEmployees && data.numberOfEmployees !== "" ? data.numberOfEmployees : "0",
+}));
+
 export const EmployeeAuthSchema = z.object({
   userId: z.string().min(1, "User ID is required"),
   companyPasskey: z.string().min(1, "Company passkey is required"),


### PR DESCRIPTION
## Summary
- enforce Clerk session auth and role checks for /api/updateCompany
- validate company settings payload with UpdateCompanySchema and stop trusting client userId
- sync employer settings UI with the new API contract and add jest coverage

## Testing
- pnpm test __tests__/api/updateCompany/updateCompany.test.ts