### PR TITLE
Add adaptive batching to predictive analysis

### DIFF
--- a/__tests__/api/predictiveDocumentAnalysis/analyzeDocumentChunks.test.ts
+++ b/__tests__/api/predictiveDocumentAnalysis/analyzeDocumentChunks.test.ts
@@ -1,0 +1,83 @@
+const mockStructuredInvoke = jest.fn().mockResolvedValue({
+    missingDocuments: [],
+    recommendations: [],
+});
+
+jest.mock("p-limit", () => ({
+    __esModule: true,
+    default: () => (fn: () => Promise<unknown>) => fn(),
+}));
+
+jest.mock("@langchain/openai", () => {
+    const MockChatOpenAI = class {
+        withStructuredOutput() {
+            return {
+                invoke: mockStructuredInvoke,
+            };
+        }
+    };
+    return {
+        __esModule: true,
+        ChatOpenAI: MockChatOpenAI,
+    };
+});
+
+import * as AnalysisEngine from "~/app/api/predictive-document-analysis/services/analysisEngine";
+import { createChunkBatches } from "~/app/api/predictive-document-analysis/utils/batching";
+import type { PdfChunk, AnalysisSpecification } from "~/app/api/predictive-document-analysis/types";
+
+describe("predictive analysis batching", () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockStructuredInvoke.mockClear();
+    });
+
+    it("groups chunks according to the configured limits", () => {
+        const chunks: PdfChunk[] = [
+            { id: 1, page: 1, content: "a".repeat(1000) },
+            { id: 2, page: 2, content: "b".repeat(1000) },
+            { id: 3, page: 3, content: "c".repeat(1000) },
+            { id: 4, page: 4, content: "d".repeat(1000) },
+            { id: 5, page: 5, content: "e".repeat(1000) },
+        ];
+
+        const batches = createChunkBatches(chunks, {
+            maxChunksPerCall: 2,
+            maxCharactersPerCall: 2500,
+        });
+
+        expect(batches).toHaveLength(3);
+        expect(batches[0]).toHaveLength(2);
+        expect(batches[1]).toHaveLength(2);
+        expect(batches[2]).toHaveLength(1);
+    });
+
+    it("caps OpenAI round trips for large documents", async () => {
+        const chunks: PdfChunk[] = Array.from({ length: 120 }, (_, index) => ({
+            id: index + 1,
+            page: index + 1,
+            content: `Chunk content ${index + 1}`,
+        }));
+
+        const specification: AnalysisSpecification = {
+            type: "general",
+            includeRelatedDocs: false,
+            existingDocuments: [],
+            title: "Sample",
+            category: "general",
+            companyId: 1,
+            documentId: 10,
+        };
+
+        const { stats } = await AnalysisEngine.analyzeDocumentChunks(
+            chunks,
+            specification,
+            2000,
+            8
+        );
+
+        expect(stats.aiCalls).toBeLessThanOrEqual(15);
+        expect(stats.totalChunks).toBe(120);
+        expect(mockStructuredInvoke).toHaveBeenCalledTimes(stats.aiCalls);
+    });
+});

--- a/src/app/api/predictive-document-analysis/services/analysisEngine.ts
+++ b/src/app/api/predictive-document-analysis/services/analysisEngine.ts
@@ -11,13 +11,15 @@ import type {
 } from "../types";
 import { ANALYSIS_TYPES } from "../types";
 import { groupContentFromChunks } from "../utils/content";
+import { createChunkBatches } from "../utils/batching";
 import { extractReferences, deduplicateReferences } from "./referenceExtractor";
 import { findSuggestedCompanyDocuments } from "./documentMatcher";
 import pLimit from "p-limit";
-const { db } = await import("../../../../server/db/index");
-const { document } = await import("~/server/db/schema");
-const { and, eq, ne } = await import("drizzle-orm");
+import { db } from "~/server/db/index";
+import { document } from "~/server/db/schema";
+import { and, eq, ne } from "drizzle-orm";
 import stringSimilarity from 'string-similarity-js';
+import { ANALYSIS_BATCH_CONFIG } from "~/lib/constants";
 
 async function withRetry<T>(
     operation: () => Promise<T>,
@@ -145,8 +147,9 @@ export async function callAIAnalysis(
         name: "analysis_result"
     });
 
+    let timeoutHandle: ReturnType<typeof setTimeout> | null = null;
     const timeoutPromise = new Promise<never>((_, reject) => {
-        setTimeout(() => {
+        timeoutHandle = setTimeout(() => {
             reject(new Error(`AI analysis timed out after ${timeoutMs}ms`));
         }, timeoutMs);
     });
@@ -167,20 +170,46 @@ export async function callAIAnalysis(
             missingDocuments: [],
             recommendations: []
         };
+    } finally {
+        if (timeoutHandle) {
+            clearTimeout(timeoutHandle);
+        }
     }
 }
 
+
+export type AnalysisRunStats = {
+    aiCalls: number;
+    batches: number;
+    averageBatchSize: number;
+    averageChunkLength: number;
+    totalChunks: number;
+};
+
+export type AnalyzeDocumentChunksResponse = {
+    result: PredictiveAnalysisResult;
+    stats: AnalysisRunStats;
+};
 
 export async function analyzeDocumentChunks(
     allChunks: PdfChunk[],
     specification: AnalysisSpecification,
     timeoutMs = 30000,
-    maxConcurrency = 20
-): Promise<PredictiveAnalysisResult> {
-    const limit = pLimit(maxConcurrency);
+    maxConcurrency = ANALYSIS_BATCH_CONFIG.MAX_CONCURRENCY
+): Promise<AnalyzeDocumentChunksResponse> {
+    const batches = createChunkBatches(allChunks, {
+        maxChunksPerCall: ANALYSIS_BATCH_CONFIG.MAX_CHUNKS_PER_CALL,
+        maxCharactersPerCall: ANALYSIS_BATCH_CONFIG.MAX_CHARACTERS_PER_CALL
+    });
 
-    const chunkPromises = allChunks.map(chunk =>
-        limit(() => callAIAnalysis([chunk], specification, timeoutMs))
+    const safeConcurrency = Math.max(
+        1,
+        Math.min(maxConcurrency, ANALYSIS_BATCH_CONFIG.MAX_CONCURRENCY)
+    );
+    const limit = pLimit(safeConcurrency);
+
+    const chunkPromises = batches.map(batch =>
+        limit(() => callAIAnalysis(batch, specification, timeoutMs))
     );
 
     try {
@@ -199,7 +228,19 @@ export async function analyzeDocumentChunks(
             await enhanceWithWebSearch(combinedResult, specification);
         }
 
-        return combinedResult;
+        const totalCharacters = allChunks.reduce((sum, chunk) => sum + (chunk.content?.length ?? 0), 0);
+        const stats: AnalysisRunStats = {
+            aiCalls: batches.length,
+            batches: batches.length,
+            averageBatchSize: batches.length > 0 ? allChunks.length / batches.length : allChunks.length,
+            averageChunkLength: allChunks.length > 0 ? totalCharacters / allChunks.length : 0,
+            totalChunks: allChunks.length
+        };
+
+        return {
+            result: combinedResult,
+            stats
+        };
     } catch (error) {
         console.error("Batch analysis error:", error);
         throw error;

--- a/src/app/api/predictive-document-analysis/utils/batching.ts
+++ b/src/app/api/predictive-document-analysis/utils/batching.ts
@@ -1,0 +1,48 @@
+import type { PdfChunk } from "../types";
+
+export type ChunkBatchingOptions = {
+    maxChunksPerCall: number;
+    maxCharactersPerCall: number;
+};
+
+/**
+ * Groups sequential chunks to keep OpenAI round trips bounded.
+ */
+export function createChunkBatches(
+    chunks: PdfChunk[],
+    options: ChunkBatchingOptions
+): PdfChunk[][] {
+    const { maxChunksPerCall, maxCharactersPerCall } = options;
+
+    if (maxChunksPerCall <= 0) {
+        throw new Error("maxChunksPerCall must be greater than zero");
+    }
+    if (maxCharactersPerCall <= 0) {
+        throw new Error("maxCharactersPerCall must be greater than zero");
+    }
+
+    const batches: PdfChunk[][] = [];
+    let currentBatch: PdfChunk[] = [];
+    let currentCharCount = 0;
+
+    for (const chunk of chunks) {
+        const chunkLength = chunk.content?.length ?? 0;
+        const wouldExceedChunkLimit = currentBatch.length >= maxChunksPerCall;
+        const wouldExceedCharLimit = currentCharCount + chunkLength > maxCharactersPerCall;
+
+        if (currentBatch.length > 0 && (wouldExceedChunkLimit || wouldExceedCharLimit)) {
+            batches.push(currentBatch);
+            currentBatch = [];
+            currentCharCount = 0;
+        }
+
+        currentBatch.push(chunk);
+        currentCharCount += chunkLength;
+    }
+
+    if (currentBatch.length > 0) {
+        batches.push(currentBatch);
+    }
+
+    return batches;
+}

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -33,6 +33,13 @@ export const DOCUMENT_LIMITS = {
   SUPPORTED_FORMATS: ['pdf', 'docx', 'doc', 'txt'] as const
 } as const;
 
+// Predictive Analysis batching
+export const ANALYSIS_BATCH_CONFIG = {
+  MAX_CHUNKS_PER_CALL: 10,
+  MAX_CHARACTERS_PER_CALL: 12000,
+  MAX_CONCURRENCY: 12
+} as const;
+
 // Priority Levels
 export const PRIORITY_LEVELS = [
   'immediate',


### PR DESCRIPTION
## Summary
- add configurable chunk batching helper and apply it inside the predictive analysis engine so GPT calls operate on grouped ranges instead of single chunks
- expose batch tuning knobs via constants, surface aiCalls metadata, and keep concurrency capped
- cover the batching logic with a dedicated test to ensure we never exceed the 15-call budget on a 120-chunk fixture

Closes #59