### PR TITLE
Lock down chat history APIs

### DIFF
--- a/__tests__/api/Questions/chatHistory.routes.test.ts
+++ b/__tests__/api/Questions/chatHistory.routes.test.ts
@@ -1,0 +1,162 @@
+import { POST as addChatHistory } from "~/app/api/Questions/add/route";
+import { POST as fetchChatHistory } from "~/app/api/Questions/fetch/route";
+
+const mockAuth = jest.fn();
+jest.mock("@clerk/nextjs/server", () => ({
+    auth: (...args: unknown[]) => mockAuth(...args),
+}));
+
+const mockSelect = jest.fn();
+const mockInsert = jest.fn();
+jest.mock("~/server/db/index", () => ({
+    db: {
+        select: (...args: unknown[]) => mockSelect(...args),
+        insert: (...args: unknown[]) => mockInsert(...args),
+    },
+}));
+
+const createLimitedSelect = (rows: unknown[]) => ({
+    from: () => ({
+        where: () => ({
+            limit: () => Promise.resolve(rows),
+        }),
+    }),
+});
+
+const createWhereSelect = (rows: unknown[]) => ({
+    from: () => ({
+        where: () => Promise.resolve(rows),
+    }),
+});
+
+describe("Chat history routes", () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    describe("POST /api/Questions/add", () => {
+        const buildRequest = (body: Record<string, unknown>) =>
+            new Request("http://localhost/api/Questions/add", {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify(body),
+            });
+
+        it("rejects unauthenticated requests", async () => {
+            mockAuth.mockResolvedValue({ userId: null });
+
+            const response = await addChatHistory(
+                buildRequest({
+                    documentId: 1,
+                    question: "Q?",
+                    documentTitle: "Doc",
+                    response: "A",
+                    pages: [1],
+                }),
+            );
+
+            expect(response.status).toBe(401);
+        });
+
+        it("prevents writing to documents outside the user's company", async () => {
+            mockAuth.mockResolvedValue({ userId: "user-1" });
+            mockSelect
+                .mockImplementationOnce(() =>
+                    createLimitedSelect([{ userId: "user-1", companyId: "10" }]),
+                )
+                .mockImplementationOnce(() =>
+                    createLimitedSelect([{ id: 5, companyId: "20", title: "Doc" }]),
+                );
+
+            const response = await addChatHistory(
+                buildRequest({
+                    documentId: 5,
+                    question: "Q?",
+                    documentTitle: "Doc",
+                    response: "A",
+                }),
+            );
+
+            expect(response.status).toBe(403);
+        });
+
+        it("stores chat history when user and document are valid", async () => {
+            mockAuth.mockResolvedValue({ userId: "user-1" });
+            mockSelect
+                .mockImplementationOnce(() =>
+                    createLimitedSelect([{ userId: "user-1", companyId: "10" }]),
+                )
+                .mockImplementationOnce(() =>
+                    createLimitedSelect([{ id: 7, companyId: "10", title: "Actual Title" }]),
+                );
+
+            const insertValues = jest.fn().mockResolvedValue(undefined);
+            mockInsert.mockReturnValueOnce({ values: insertValues });
+
+            const response = await addChatHistory(
+                buildRequest({
+                    documentId: 7,
+                    question: "Q?",
+                    documentTitle: "Ignored",
+                    response: "Answer",
+                    pages: [2, 3],
+                }),
+            );
+
+            expect(response.status).toBe(201);
+            expect(insertValues).toHaveBeenCalledWith({
+                UserId: "user-1",
+                documentId: "7",
+                documentTitle: "Actual Title",
+                question: "Q?",
+                response: "Answer",
+                pages: [2, 3],
+            });
+        });
+    });
+
+    describe("POST /api/Questions/fetch", () => {
+        const buildRequest = (body: Record<string, unknown>) =>
+            new Request("http://localhost/api/Questions/fetch", {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify(body),
+            });
+
+        it("rejects unauthenticated requests", async () => {
+            mockAuth.mockResolvedValue({ userId: null });
+
+            const response = await fetchChatHistory(
+                buildRequest({
+                    documentId: 9,
+                }),
+            );
+
+            expect(response.status).toBe(401);
+        });
+
+        it("returns chat history for valid users and documents", async () => {
+            mockAuth.mockResolvedValue({ userId: "user-1" });
+            mockSelect
+                .mockImplementationOnce(() =>
+                    createLimitedSelect([{ userId: "user-1", companyId: "10" }]),
+                )
+                .mockImplementationOnce(() =>
+                    createLimitedSelect([{ id: 9, companyId: "10" }]),
+                )
+                .mockImplementationOnce(() =>
+                    createWhereSelect([{ id: 1, question: "Q?", response: "A" }]),
+                );
+
+            const response = await fetchChatHistory(
+                buildRequest({
+                    documentId: 9,
+                }),
+            );
+
+            expect(response.status).toBe(200);
+            const payload = await response.json();
+            expect(payload.chatHistory).toEqual([{ id: 1, question: "Q?", response: "A" }]);
+        });
+    });
+});

--- a/src/app/api/Questions/add/route.ts
+++ b/src/app/api/Questions/add/route.ts
@@ -1,32 +1,76 @@
 import { NextResponse } from "next/server";
-import { db } from "~/server/db/index";
-import { ChatHistory } from "~/server/db/schema";
+import { auth } from "@clerk/nextjs/server";
+import { eq } from "drizzle-orm";
 
-type PostBody = {
-    userId: string;
-    question: string;
-    documentId: string;
-    documentTitle: string;
-    response: string;
-    pages: number[];
-};
+import { db } from "~/server/db/index";
+import { ChatHistory, users, document } from "~/server/db/schema";
+import { validateRequestBody, ChatHistoryAddSchema } from "~/lib/validation";
 
 export async function POST(request: Request) {
     try {
-        const { userId, question, documentId, documentTitle, response, pages } = (await request.json()) as PostBody;
+        const validation = await validateRequestBody(request, ChatHistoryAddSchema);
+        if (!validation.success) {
+            return validation.response;
+        }
+
+        const { documentId, question, documentTitle, response, pages } = validation.data;
+
+        const { userId } = await auth();
+        if (!userId) {
+            return NextResponse.json({
+                success: false,
+                message: "Unauthorized"
+            }, { status: 401 });
+        }
+
+        const [requestingUser] = await db
+            .select()
+            .from(users)
+            .where(eq(users.userId, userId))
+            .limit(1);
+
+        if (!requestingUser) {
+            return NextResponse.json({
+                success: false,
+                message: "Invalid user."
+            }, { status: 401 });
+        }
+
+        const [targetDocument] = await db
+            .select()
+            .from(document)
+            .where(eq(document.id, documentId))
+            .limit(1);
+
+        if (!targetDocument) {
+            return NextResponse.json({
+                success: false,
+                message: "Document not found."
+            }, { status: 404 });
+        }
+
+        if (targetDocument.companyId !== requestingUser.companyId) {
+            return NextResponse.json({
+                success: false,
+                message: "You do not have access to this document."
+            }, { status: 403 });
+        }
 
         await db.insert(ChatHistory).values({
             UserId: userId,
-            documentId: documentId,
-            documentTitle: documentTitle,
-            question: question,
-            response: response,
-            pages: pages,
+            documentId: targetDocument.id.toString(),
+            documentTitle: targetDocument.title ?? documentTitle,
+            question,
+            response,
+            pages: pages ?? [],
         });
 
-        return NextResponse.json({ success: true });
+        return NextResponse.json({ success: true }, { status: 201 });
     } catch (error: unknown) {
         console.error(error);
-        return NextResponse.json({ error }, { status: 500 });
+        return NextResponse.json({
+            success: false,
+            error: error instanceof Error ? error.message : "Unknown error"
+        }, { status: 500 });
     }
 }

--- a/src/app/api/Questions/fetch/route.ts
+++ b/src/app/api/Questions/fetch/route.ts
@@ -1,31 +1,80 @@
 import { NextResponse } from "next/server";
-import { db } from "~/server/db/index";
-import { ChatHistory } from "~/server/db/schema";
-import {and, eq} from "drizzle-orm";
+import { auth } from "@clerk/nextjs/server";
+import { and, eq } from "drizzle-orm";
 
-type PostBody = {
-    userId: string;
-    documentId: string;
-};
+import { db } from "~/server/db/index";
+import { ChatHistory, users, document } from "~/server/db/schema";
+import { validateRequestBody, ChatHistoryFetchSchema } from "~/lib/validation";
 
 export async function POST(request: Request) {
     try {
-        // Parse the request body for userId
-        const { userId, documentId } = (await request.json()) as PostBody;
+        const validation = await validateRequestBody(request, ChatHistoryFetchSchema);
+        if (!validation.success) {
+            return validation.response;
+        }
 
-        // Retrieve all chat history records for the specified user
+        const { documentId } = validation.data;
+
+        const { userId } = await auth();
+        if (!userId) {
+            return NextResponse.json({
+                success: false,
+                message: "Unauthorized"
+            }, { status: 401 });
+        }
+
+        const [requestingUser] = await db
+            .select()
+            .from(users)
+            .where(eq(users.userId, userId))
+            .limit(1);
+
+        if (!requestingUser) {
+            return NextResponse.json({
+                success: false,
+                message: "Invalid user."
+            }, { status: 401 });
+        }
+
+        const [targetDocument] = await db
+            .select()
+            .from(document)
+            .where(eq(document.id, documentId))
+            .limit(1);
+
+        if (!targetDocument) {
+            return NextResponse.json({
+                success: false,
+                message: "Document not found."
+            }, { status: 404 });
+        }
+
+        if (targetDocument.companyId !== requestingUser.companyId) {
+            return NextResponse.json({
+                success: false,
+                message: "You do not have access to this document."
+            }, { status: 403 });
+        }
+
         const userChatHistory = await db
             .select()
             .from(ChatHistory)
-            .where(and(eq(ChatHistory.UserId, userId), eq(ChatHistory.documentId, documentId)));
+            .where(
+                and(
+                    eq(ChatHistory.UserId, userId),
+                    eq(ChatHistory.documentId, targetDocument.id.toString())
+                )
+            );
 
-        // Return the results
         return NextResponse.json({
             success: true,
             chatHistory: userChatHistory,
         });
     } catch (error: unknown) {
         console.error(error);
-        return NextResponse.json({ error }, { status: 500 });
+        return NextResponse.json({
+            success: false,
+            error: error instanceof Error ? error.message : "Unknown error"
+        }, { status: 500 });
     }
 }

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -79,6 +79,18 @@ export const QuestionSchema = z.object({
   searchScope: data.searchScope ?? "document" as const,
 }));
 
+export const ChatHistoryAddSchema = z.object({
+  documentId: z.number().int().positive("Document ID must be a positive integer"),
+  question: z.string().min(1, "Question is required").max(2000, "Question is too long"),
+  documentTitle: z.string().min(1, "Document title is required").max(256, "Document title is too long"),
+  response: z.string().min(1, "Response is required"),
+  pages: z.array(z.number().int().positive()).max(50).optional(),
+});
+
+export const ChatHistoryFetchSchema = z.object({
+  documentId: z.number().int().positive("Document ID must be a positive integer"),
+});
+
 export const DeleteDocumentSchema = z.object({
   docId: z.string().min(1, "Document ID is required"),
 });


### PR DESCRIPTION
## Summary
- add Clerk auth, tenant checks, and Zod validation to the chat history add/fetch routes so only authorized users can write/read entries
- ignore caller-supplied identifiers by resolving the requesting user and document directly from the database
- add targeted Jest coverage for both endpoints to guard regressions

## Testing
- pnpm test __tests__/api/Questions/chatHistory.routes.test.ts
