### PR TITLE
fix: add keyboard navigation support to interactive elements

### DIFF
--- a/src/app/employer/home/page.tsx
+++ b/src/app/employer/home/page.tsx
@@ -143,6 +143,12 @@ const HomeScreen = () => {
                             key={index}
                             className={styles.menuCard}
                             onClick={() => handleNavigation(option.path)}
+                            onKeyDown={(e) => {
+                                if (e.key === 'Enter' || e.key === ' ') {
+                                    e.preventDefault();
+                                    handleNavigation(option.path);
+                                }
+                            }}
                             role="button"
                             tabIndex={0}
                         >

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -21,18 +21,29 @@ const RoleCard: React.FC<RoleCardProps> = ({
                                                icon,
                                                isSelected,
                                                onClick,
-                                           }) => (
-    <div
-        className={`${styles.roleCard} ${isSelected ? styles.selected : ''}`}
-        onClick={onClick}
-        role="button"
-        tabIndex={0}
-    >
-        <div className={styles.iconWrapper}>{icon}</div>
-        <h2 className={styles.cardTitle}>{title}</h2>
-        <p className={styles.cardDescription}>{description}</p>
-    </div>
-);
+                                           }) => {
+    const handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            onClick();
+        }
+    };
+
+    return (
+        <div
+            className={`${styles.roleCard} ${isSelected ? styles.selected : ''}`}
+            onClick={onClick}
+            onKeyDown={handleKeyDown}
+            role="button"
+            tabIndex={0}
+            aria-pressed={isSelected}
+        >
+            <div className={styles.iconWrapper}>{icon}</div>
+            <h2 className={styles.cardTitle}>{title}</h2>
+            <p className={styles.cardDescription}>{description}</p>
+        </div>
+    );
+};
 
 const RoleSelection: React.FC = () => {
     const [selectedRole, setSelectedRole] = useState<'employer' | 'employee' | null>(null);


### PR DESCRIPTION
## Summary

This PR adds keyboard navigation support to interactive elements that were missing `onKeyDown` handlers, improving accessibility for keyboard-only users.

### Problem

Several interactive `div` elements in the codebase had:
- `role="button"` - correctly indicating they are interactive
- `tabIndex={0}` - making them focusable via keyboard

However, they were **missing** `onKeyDown` handlers, meaning keyboard users could focus these elements but **could not activate them** using Enter or Space keys.

### Solution

Added proper keyboard event handlers to affected components:

**1. `src/app/signup/page.tsx` - RoleCard Component**
```tsx
const handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
    if (e.key === 'Enter' || e.key === ' ') {
        e.preventDefault();
        onClick();
    }
};
```
- Added `onKeyDown` handler for Enter/Space key activation
- Added `aria-pressed` attribute to indicate toggle state
- Converted arrow function to regular function for cleaner handler definition

**2. `src/app/employer/home/page.tsx` - Menu Cards**
```tsx
onKeyDown={(e) => {
    if (e.key === 'Enter' || e.key === ' ') {
        e.preventDefault();
        handleNavigation(option.path);
    }
}}
```
- Added inline `onKeyDown` handler for navigation cards

### WCAG Compliance

This fix addresses **WCAG 2.1 Success Criterion 2.1.1 (Keyboard)**:
> All functionality of the content is operable through a keyboard interface.

### Testing

- [ ] Role selection cards can be activated with Enter key
- [ ] Role selection cards can be activated with Space key
- [ ] Menu cards on home page can be activated with Enter key
- [ ] Menu cards on home page can be activated with Space key
- [ ] Tab navigation order is preserved
- [ ] No regressions in mouse interaction

### Files Changed

- `src/app/signup/page.tsx` - RoleCard component keyboard support
- `src/app/employer/home/page.tsx` - Menu card keyboard support