### PR TITLE
fix: correct ChatHistory schema column names and types

### DIFF
--- a/src/server/db/schema/base.ts
+++ b/src/server/db/schema/base.ts
@@ -86,10 +86,10 @@ export const pdfChunks = pgTable("pdf_chunks", {
 
 export const ChatHistory = pgTable("chatHistory", {
     id: serial("id").primaryKey(),
-    UserId: varchar("company id", { length: 256 }).notNull(),
-    documentId: varchar("document id", { length: 256 }).notNull(),
-    documentTitle: varchar("document title", { length: 256 }).notNull(),
-    question: varchar("question", { length: 256 }).notNull(),
+    UserId: varchar("user_id", { length: 256 }).notNull(),
+    documentId: varchar("document_id", { length: 256 }).notNull(),
+    documentTitle: varchar("document_title", { length: 256 }).notNull(),
+    question: text("question").notNull(),
     response: text("response").notNull(),
     chatId: varchar("chat_id", { length: 256 }),
     queryType: varchar("query_type", { length: 20, enum: ["simple", "advanced"] }).default(


### PR DESCRIPTION
## Summary

This PR fixes several issues in the ChatHistory database schema:

### Changes

1. **Fix mislabeled UserId column**: The column was incorrectly labeled as `"company id"` in the database, now corrected to `"user_id"`

2. **Standardize column naming to snake_case**:
   - `documentId`: `"document id"` → `"document_id"`
   - `documentTitle`: `"document title"` → `"document_title"`

3. **Change question field type**: Changed from `varchar(256)` to `text` to prevent truncation of longer user questions

### Why these changes matter

- **Data integrity**: The mislabeled `UserId` column could cause confusion during database queries and maintenance
- **Consistency**: Using snake_case for all column names follows PostgreSQL conventions and matches other tables in the schema
- **User experience**: The varchar(256) limit on questions could silently truncate user input, leading to incomplete chat history records

### Migration Note

This is a schema change that will require a database migration. The changes are:
- Column renames (no data loss)
- Type change from varchar(256) to text (no data loss, text can store more data)

## Test Plan

- [ ] Run `drizzle-kit generate` to create migration
- [ ] Review generated migration SQL
- [ ] Test migration on development database
- [ ] Verify chat history functionality works correctly