### PR TITLE
fix: improve error handling in employer company signup route

### DIFF
--- a/src/app/api/signup/employerCompany/route.ts
+++ b/src/app/api/signup/employerCompany/route.ts
@@ -1,8 +1,7 @@
 import {db} from "~/server/db";
 import {company, users} from "~/server/db/schema";
-import {NextResponse} from "next/server";
-import console from "console";
 import {eq} from "drizzle-orm";
+import {handleApiError, createSuccessResponse, createValidationError} from "~/lib/api-utils";
 
 type PostBody = {
     userId: string;
@@ -27,9 +26,8 @@ export async function POST(request: Request) {
             .where(eq(company.name, companyName));
 
         if (existingCompany) {
-            return NextResponse.json(
-                { error: "Company already exists." },
-                { status: 400 }
+            return createValidationError(
+                "Company already exists. Please use a different company name."
             );
         }
 
@@ -45,9 +43,8 @@ export async function POST(request: Request) {
             .returning({ id: company.id });
 
         if(!newCompany) {
-            return NextResponse.json(
-                { error: "Could not create company." },
-                { status: 400 }
+            return createValidationError(
+                "Could not create company. Please try again later."
             );
         }
 
@@ -63,14 +60,13 @@ export async function POST(request: Request) {
             role: "owner",
         });
 
-        return NextResponse.json({ success: true });
-
+        return createSuccessResponse(
+            { userId, role: "owner" },
+            "Company and owner account created successfully."
+        );
     }
     catch (error: unknown) {
-        console.error(error);
-        return NextResponse.json({ error: error}, { status: 500 });
+        console.error("Error during employer company signup:", error);
+        return handleApiError(error);
     }
 }
-
-
-


### PR DESCRIPTION
## Summary

This PR fixes a bug in the employer company signup route where error handling was inconsistent and potentially problematic.

### Problem

The `src/app/api/signup/employerCompany/route.ts` had several issues:

1. **Serialization Bug**: The catch block returned `{ error: error }` directly, which would fail to serialize properly (Error objects don't serialize to JSON as expected) or potentially leak internal error details
2. **Inconsistent Response Format**: Used raw `NextResponse.json()` instead of the project's standardized API utilities
3. **Missing Error Context**: Error messages lacked descriptive context for users
4. **Unused Import**: Imported `console` from "console" unnecessarily

### Solution

- Use `handleApiError()` utility from `~/lib/api-utils` for proper error handling
- Use `createValidationError()` for validation failures with user-friendly messages
- Use `createSuccessResponse()` for consistent success response format
- Remove unused `NextResponse` import

### Changes

| Before | After |
|--------|-------|
| `NextResponse.json({ error: error }, { status: 500 })` | `handleApiError(error)` |
| `NextResponse.json({ error: "Company already exists." }, { status: 400 })` | `createValidationError("Company already exists. Please use a different company name.")` |
| `NextResponse.json({ success: true })` | `createSuccessResponse({ userId, role: "owner" }, "Company and owner account created successfully.")` |

### Benefits

- **Consistent API responses**: Matches other signup routes (employee, employer)
- **Better error messages**: User-friendly, actionable error messages
- **Proper serialization**: No more serialization issues with Error objects
- **Type safety**: Uses typed response utilities

### Testing

- [ ] Manual testing of company signup flow
- [ ] Verify error responses are properly formatted
- [ ] Verify success responses include expected data

### Breaking Changes

None - Response structure now follows the same pattern as other signup routes.