### PR TITLE
feat(constants): add BATCH_UPLOAD_CONFIG for multi-file upload limits

### DIFF
--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -37,6 +37,21 @@ export const DOCUMENT_LIMITS = {
   ] as const
 } as const;
 
+// Batch Document Upload
+export const BATCH_UPLOAD_CONFIG = {
+  /** Maximum number of files accepted in a single batch request. */
+  MAX_FILES: 20,
+  /** Combined size cap for all files in a batch (MB). */
+  MAX_TOTAL_SIZE_MB: 500,
+  /** Number of files processed concurrently through the OCR/embedding pipeline. */
+  MAX_CONCURRENT_UPLOADS: 3,
+  /** Front-end polling interval when waiting for batch job completion (ms). */
+  QUEUE_POLL_INTERVAL_MS: 2000,
+} as const;
+
+/** Convenience alias used by upload route validation. */
+export const BATCH_UPLOAD_MAX_FILES = BATCH_UPLOAD_CONFIG.MAX_FILES;
+
 // Predictive Analysis batching
 export const ANALYSIS_BATCH_CONFIG = {
   MAX_CHUNKS_PER_CALL: 10,


### PR DESCRIPTION
## Summary

Closes part of #186.

Issue #186 calls for `BATCH_UPLOAD_MAX_FILES` to be defined in `src/lib/constants.ts` so the batch upload route, the upload-queue UI component, and any documentation can all import from one place instead of scattering magic numbers across the codebase.

This PR adds:

- **`BATCH_UPLOAD_CONFIG`** — a grouped `as const` object that mirrors the existing `DOCUMENT_LIMITS` / `ANALYSIS_BATCH_CONFIG` style:
  | Key | Value | Rationale |
  |-----|-------|-----------|
  | `MAX_FILES` | 20 | Keeps a single batch manageable without exhausting the OCR quota |
  | `MAX_TOTAL_SIZE_MB` | 500 | 10× the single-file cap; prevents runaway storage use |
  | `MAX_CONCURRENT_UPLOADS` | 3 | Matches the Inngest concurrency ceiling used for OCR jobs |
  | `QUEUE_POLL_INTERVAL_MS` | 2000 | Balances UI responsiveness against server polling load |

- **`BATCH_UPLOAD_MAX_FILES`** — a flat named export (`= BATCH_UPLOAD_CONFIG.MAX_FILES`) for call-sites that only need the file count and should not need to destructure the whole config object.

## Changes

- `src/lib/constants.ts` — additive only; no existing exports modified

## Test plan

- [ ] Import `BATCH_UPLOAD_MAX_FILES` from `~/lib/constants` in a new route or test and verify the value is `20`
- [ ] Import `BATCH_UPLOAD_CONFIG.MAX_CONCURRENT_UPLOADS` and verify it is `3`
- [ ] Confirm TypeScript sees both exports as `readonly` (no `as const` widening)
