### PR TITLE
fix(documentQ&A): filter recommendedPages to only AI-cited pages

### DIFF
--- a/src/app/api/agents/documentQ&A/AIQuery/route.ts
+++ b/src/app/api/agents/documentQ&A/AIQuery/route.ts
@@ -23,6 +23,7 @@ import {
     getChatModel,
     getEmbeddings,
     extractRecommendedPages,
+    filterPagesByAICitation,
 } from "../services";
 import type { AIModelType } from "../services";
 import type { SYSTEM_PROMPTS } from "../services/prompts";
@@ -279,10 +280,13 @@ export async function POST(request: Request) {
 
             recordResult("success");
 
+            const allCandidatePages = extractRecommendedPages(documents);
+            const recommendedPages = filterPagesByAICitation(summarizedAnswer, allCandidatePages);
+
             return NextResponse.json({
                 success: true,
                 summarizedAnswer,
-                recommendedPages: extractRecommendedPages(documents),
+                recommendedPages,
                 retrievalMethod,
                 processingTimeMs: totalTime,
                 chunksAnalyzed: documents.length,

--- a/src/app/api/agents/documentQ&A/services/index.ts
+++ b/src/app/api/agents/documentQ&A/services/index.ts
@@ -12,7 +12,7 @@
 // Functions
 export { normalizeModelContent } from "./normalizeModelContent";
 export { performWebSearch } from "./webSearch";
-export { buildReferences, extractRecommendedPages } from "./references";
+export { buildReferences, extractRecommendedPages, filterPagesByAICitation } from "./references";
 export { performTavilySearch } from "./tavilySearch";
 export { executeWebSearchAgent } from "./webSearchAgent";
 export { SYSTEM_PROMPTS, getSystemPrompt, getWebSearchInstruction } from "./prompts";


### PR DESCRIPTION
## Summary

Closes #90.

Currently  returns a page number for every retrieved chunk fed into the context window, even if the AI never mentioned those pages in its answer. This surfaces citations for pages the model did not actually use.

This PR adds  and wires it into the  endpoint.

## How it works

1. After the AI generates ,  scans the text for page reference patterns: "page 3", "pages 4-6", "p. 5", "(page 2)", etc.
2. It collects the cited page numbers and returns the **intersection** with  (the pages from retrieved chunks).
3. Two safe-fallbacks prevent regressions:
   - If the model produces **no explicit page citations**, all candidate pages are returned unchanged (same behavior as today).
   - If every cited page is **outside the candidate set** (hallucinated number), all candidate pages are returned unchanged.

## Changes

| File | Change |
|------|--------|
|  | New exported  function |
|  | Re-exports the new function for other endpoints to adopt incrementally |
|  | Applies  to the AI answer before building the JSON response |

## Test plan

- [ ] Ask a question whose answer explicitly cites specific pages — verify  contains only those pages
- [ ] Ask a broad question where the model does not write "page N" — verify  still returns all retrieved-chunk pages (fallback path)
- [ ] Confirm  and  endpoints are unaffected
