### PR TITLE
fix: clear timeout handle in extractReferences to prevent resource leak

### DIFF
--- a/src/app/api/agents/predictive-document-analysis/services/referenceExtractor.ts
+++ b/src/app/api/agents/predictive-document-analysis/services/referenceExtractor.ts
@@ -53,8 +53,9 @@ export async function extractReferences(
         name: "reference_extraction"
     });
 
+    let timeoutHandle: ReturnType<typeof setTimeout> | null = null;
     const timeoutPromise = new Promise<never>((_, reject) => {
-        setTimeout(() => {
+        timeoutHandle = setTimeout(() => {
             reject(new Error(`Reference extraction timed out after ${timeoutMs}ms`));
         }, timeoutMs);
     });
@@ -67,15 +68,19 @@ export async function extractReferences(
     try {
         const response = await Promise.race([aiCallPromise, timeoutPromise]);
         const references = response.references;
-        
-        const filteredReferences = references.filter(ref => 
+
+        const filteredReferences = references.filter(ref =>
             hasSpecificIdentifier(ref.documentName)
         );
-        
+
         return filteredReferences;
     } catch (error) {
         console.error("Reference extraction error:", error);
         return [];
+    } finally {
+        if (timeoutHandle) {
+            clearTimeout(timeoutHandle);
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

`extractReferences` in `referenceExtractor.ts` creates a `setTimeout`-based race promise but never stores or clears the timer handle. When the AI call finishes before the timeout fires, the Node.js timer keeps the closure alive until it eventually triggers, delaying GC and causing unnecessary overhead — especially under concurrent load.

The pattern is already correctly implemented in `callAIAnalysis` inside `analysisEngine.ts` (which stores the handle and calls `clearTimeout` in a `finally` block). This PR applies the same fix to `referenceExtractor.ts`.

**Changes:**
- Store the `setTimeout` return value in `timeoutHandle`
- Add a `finally` block that calls `clearTimeout(timeoutHandle)` after the `Promise.race` settles

## Test plan
- [ ] Existing unit tests pass (`pnpm test`)
- [ ] Verify `extractReferences` still times out correctly when the AI call stalls beyond `timeoutMs`
- [ ] Verify no timer warnings appear in Node.js when the AI call completes before the timeout