### PR TITLE
fix: assign return value of deduplicateReferences in enhanceWithCompanyDocuments

### DIFF
--- a/src/app/api/agents/predictive-document-analysis/services/analysisEngine.ts
+++ b/src/app/api/agents/predictive-document-analysis/services/analysisEngine.ts
@@ -264,8 +264,8 @@ async function enhanceWithCompanyDocuments(
     timeoutMs: number
 ): Promise<void> {
 
-    const references = await extractReferences(allChunks, timeoutMs);
-    deduplicateReferences(references);
+    const rawReferences = await extractReferences(allChunks, timeoutMs);
+    const references = deduplicateReferences(rawReferences);
 
     const otherDocsQuery = await withRetry(() => db.select({ 
         id: document.id, 


### PR DESCRIPTION
## Summary

`deduplicateReferences` is a pure function — it returns a **new** filtered array and does not mutate its input. In `enhanceWithCompanyDocuments` (inside `analysisEngine.ts`) the call was:

```ts
const references = await extractReferences(allChunks, timeoutMs);
deduplicateReferences(references); // return value discarded
```

Because the return value was thrown away, the deduplication had no effect and duplicate references could be passed along to subsequent processing.

**Fix:** capture the return value so the deduplicated list is what the rest of the function operates on.

```ts
const rawReferences = await extractReferences(allChunks, timeoutMs);
const references = deduplicateReferences(rawReferences);
```

## Test plan
- [ ] Existing unit tests pass (`pnpm test`)
- [ ] Manually verify that when a document references the same exhibit twice, `enhanceWithCompanyDocuments` no longer processes duplicate entries