### PR TITLE
Lau 14 pipeline docs

### DIFF
--- a/docs/pipeline/pipeline-architecture.md
+++ b/docs/pipeline/pipeline-architecture.md
@@ -1,0 +1,164 @@
+# Document Ingestion Pipeline
+
+> Grounded in `main` as of 2026-07-19. 
+
+---
+
+## 1. Summary
+
+A document is uploaded over HTTP, recorded as a `document` + `ocr_jobs(queued)` row, and
+an Inngest event `document/process.requested` is dispatched. One durable function
+(`process-document`) runs stages **A → G** inline as memoized steps: route → OCR → chunk →
+embed/store → finalize → GraphRAG extract (Postgres) → Neo4j mirror. On success it chains
+`company-metadata/extract.requested` (and, when re-processing a version,
+`notes-anchors/rehydrate.requested`). ZIP uploads fan out into child documents; text/code
+files take a fast path that skips OCR routing.
+
+**Stores:** Postgres + pgvector (relational, vectors, graph source of truth), Neo4j (graph
+mirror), object storage (raw bytes).
+
+---
+
+## 2. Where the code lives
+
+```
+HTTP upload          apps/web  …/api/uploadDocument + document-upload.ts
+       ↓
+Inngest dispatch     packages/core  …/ocr/trigger.ts
+       ↓
+process-document     apps/web  …/inngest/functions/processDocument.ts
+       ↓
+runDocIngestionTool  packages/features  …/doc-ingestion/index.ts   ← stages A–G
+       ↓
+OCR / embed / graph  packages/core  …/ocr/processor.ts, …/graph/, …/ingestion/
+```
+
+---
+
+## 3. Flow
+
+```mermaid
+flowchart TD
+  Upload[HTTP upload] --> Rows["document + ocr_jobs(queued)"]
+  Rows --> Event["Inngest: document/process.requested"]
+  Event --> Branch{Type?}
+
+  Branch -->|ZIP| Zip[Extract children + fan-out events]
+  Zip --> Event
+
+  Branch -->|text/code| Fast[Fast path: skip OCR routing]
+  Branch -->|other| AB[A/B Route + Normalize/OCR]
+
+  Fast --> C[C Chunk]
+  AB --> C
+  C --> D[D Embed + store chunks]
+  D --> E[E Finalize]
+  E --> FG[F GraphRAG → G Neo4j mirror]
+  FG -.->|fail-soft| Meta
+  E --> Meta["company-metadata/extract"]
+  E -.->|if versionId| Notes["notes-anchors/rehydrate"]
+```
+
+### Stages (A → G)
+
+Orchestrator: [`runDocIngestionTool`](../../packages/features/src/doc-ingestion/index.ts).
+Each `runStep` becomes an Inngest `step.run` (memoized on retry).
+
+| Step | What | Writes |
+|------|------|--------|
+| Upload / dispatch | HTTP + Inngest event | `document`, `document_versions`, `ocr_jobs(queued)` |
+| **A** Route | Pick OCR path (SigLIP optional) | — |
+| **B** Normalize / OCR | Azure / Landing.AI / Datalab / OSS / pdfjs; VLM enrichment | pages → `ocr_jobs.ocrResult` |
+| **C** Chunk | Parent/child text units | chunks → `ocr_jobs.ocrResult` |
+| **D** Embed / store | OpenAI 1536-dim **or** sidecar `/embed` | `document_structure`, `document_context_chunks`, `document_retrieval_chunks` |
+| **E** Finalize | Mark success | `document_metadata`; `ocrProcessed=true`; `ocr_jobs.status=completed` |
+| **F** GraphRAG | Entities + relationships (one step) | Postgres `kg_*` |
+| **G** Neo4j sync | Mirror from `kg_*` | `:Entity` / `:Section` + edges |
+| Downstream | Separate Inngest fns | `company_metadata`; note-anchor rehydrate |
+
+**A/B in code:** Azure PDFs use `step-a-router` + `step-b-normalize`; everything else uses one
+`step-ab-ingest` step. There is no separate “F2” — entities and relationships are extracted
+together.
+
+**Branches** ([`processDocument.ts`](../../apps/web/src/server/inngest/functions/processDocument.ts)):
+
+- **ZIP** — extract entries (cap 500, 10 MB/file), insert child docs + jobs, fan out events in
+  batches of 10, delete the original ZIP doc. Child `putFile` bypasses the storage facade
+  (imports Vercel Blob directly) — a known footgun.
+- **Text fast-path** — mime/extension skip OCR (`fastTextPath: true`) → chunk/embed onward.
+
+**Inngest config:** `retries: 5`, concurrency 3, throttle 30/min, finish timeout 120m, plus
+`onFailure`.
+
+---
+
+## 4. What gets written
+
+| Store | Pipeline tables / artifacts |
+|-------|-----------------------------|
+| **Postgres** | `document`, `ocr_jobs` (job + scratch state in `ocrResult`), `document_structure`, `document_context_chunks`, `document_retrieval_chunks` (`vector(1536)` + short `vector(512)`), `document_metadata`, `kg_entities` / `kg_entity_mentions` / `kg_relationships` |
+| **Neo4j** | Mirror only — `:Entity`, `:Section`, `:MENTIONED_IN`, dynamic rel types. Full text stays in Postgres. |
+| **Object storage** | Raw bytes via [`storage.ts`](../../apps/web/src/lib/storage.ts) (`s3` or `database`). |
+
+Schema sources: [`packages/core/src/db/schema/`](../../packages/core/src/db/schema/),
+[`neo4j-sync.ts`](../../packages/core/src/graph/neo4j-sync.ts).
+
+Postgres `kg_*` is the graph source of truth; Neo4j is the mirror.
+
+---
+
+## 5. What “done” means
+
+| Milestone | Meaning |
+|-----------|---------|
+| After **E** | Doc is searchable (chunks + embeddings). UI treats `ocrProcessed=true` as ready. Job is `completed`. |
+| After **F/G** | Graph enrichment — **optional**. Fail-soft: a `completed` doc may have zero `kg_*` / Neo4j nodes. |
+| Downstream | Company metadata refresh; on re-process with `versionId`, sticky-note anchors are rehydrated against new chunks. |
+
+`completed` ≠ “fully enriched.” It means fail-hard stages (OCR, embed, DB store) succeeded.
+
+---
+
+## 6. How to read progress 
+
+There is **no** single `UPLOADED → … → EMBEDDED` enum. Infer progress from
+`ocr_jobs.status` + `document.ocrProcessed` / `ocrMetadata` + presence of chunk/`kg_*` rows
++ the Inngest run.
+
+The Inngest caller always passes `updateJobStatus: false` and `markFailureInDb: false`, so:
+
+```
+ocr_jobs.status:  queued  ──(Step E)──▶  completed
+                     │
+                     └──(fail after 5 retries)──▶  stays queued forever
+                            onFailure: document.ocrProcessed=true
+                                       ocrMetadata.error="processing_failed"
+```
+
+- `processing` / `failed` are **never written** on the live path (gated flags; effectively dead).
+- A **failed** doc looks “processed” on `document` while its job stays `queued` — same job
+  status as an in-flight doc. Check `ocrMetadata` and Inngest, not status alone.
+
+---
+
+## 7. Dependencies & failure posture
+
+**Required for a successful ingest:** Postgres + pgvector, Inngest, object storage, an
+embedding producer (OpenAI **or** sidecar `/embed` — dims must match `vector(1536)`),
+plus an OCR path for non-text files.
+
+**Optional:** Neo4j, ML sidecar NER, cloud OCR providers (local can use pdfjs / OSS), VLM
+enrichment.
+
+| Kind | Stages | Effect |
+|------|--------|--------|
+| **Fail-hard** | OCR, embedding, DB storage | Inngest retries 5× → `onFailure` (job stays `queued`) |
+| **Fail-soft** | VLM enrichment, Step F, Step G | Doc still marked `completed` |
+
+**“Sidecar” naming trap:** `SIDECAR_URL` points at an **external** ML worker (`/embed`,
+`/extract-entities`, `/rerank`). This repo’s [`sidecar/`](../../sidecar/app/main.py) is a
+separate DOCX/Whisper service — it does **not** implement those endpoints.
+
+**Idempotency (short):** Inngest step memoization, chunk `contentHash` dedup, Neo4j `MERGE`,
+and KG upserts are safe. `createRootStructure` and `document_metadata` insert are **not** —
+retries can duplicate. ZIP extract is the riskiest non-idempotent step.

--- a/docs/pipeline/pipeline-diagram.mmd
+++ b/docs/pipeline/pipeline-diagram.mmd
@@ -1,0 +1,80 @@
+```mermaid
+
+%%{init: {'theme': 'dark', 'themeVariables': {'fontSize': '14px'}}}%%
+flowchart TD
+
+    subgraph LEGEND["Legend"]
+        direction LR
+        L1["Fail-hard stage<br/>(5 retries → stuck)"]:::failhard
+        L2["Fail-soft stage<br/>(silent, optional)"]:::failsoft
+        L3["Persisted write"]:::writeNode
+        L4["External dependency"]:::external
+        L5["User-facing done"]:::terminal
+    end
+
+    subgraph MAIN["Document Ingestion Pipeline — Stages A→G"]
+        direction TB
+
+        U["HTTP Upload"] --> REC["document + document_versions created<br/>ocr_jobs.status = queued"]:::writeNode
+        REC --> DISP["Inngest event fired:<br/>document/process.requested"]
+        DISP --> ROUTE{"A · Route by file type"}
+
+        ROUTE -->|"ZIP"| ZIP["Extract entries (≤500 files, ≤10MB each)<br/>insert child docs + child ocr_jobs<br/>fan out in batches of 10<br/>delete original ZIP doc"]
+        ZIP -.->|"re-dispatch per child"| DISP
+
+        ROUTE -->|"text / code"| FAST["Fast path — OCR skipped entirely"]
+        ROUTE -->|"everything else"| OCR["B · Normalize / OCR<br/>Azure · Landing.AI · Datalab · OSS · pdfjs<br/>(+ optional VLM enrichment)"]:::failhard
+
+        OCR --> OCRWRITE["writes: pages → ocr_jobs.ocrResult"]:::writeNode
+        OCR -.->|"fails all 5 retries"| FAIL["ocr_jobs.status stays 'queued' — forever<br/>onFailure → document.ocrProcessed = true<br/>ocrMetadata.error = 'processing_failed'<br/>⚠ looks identical to a doc still in progress"]:::failure
+
+        FAST --> CHUNK
+        OCRWRITE --> CHUNK["C · Chunk<br/>(parent/child text units)"]:::failhard
+        CHUNK --> CHUNKWRITE["writes: chunks → ocr_jobs.ocrResult"]:::writeNode
+
+        CHUNKWRITE --> EMBED["D · Embed + Store<br/>OpenAI (1536-dim) or sidecar /embed"]:::failhard
+        EMBED --> EMBEDWRITE["writes: document_structure,<br/>document_context_chunks,<br/>document_retrieval_chunks (vector 1536 + short 512)"]:::writeNode
+
+        EMBEDWRITE --> FIN["E · Finalize"]:::failhard
+        FIN --> FINWRITE["writes: document_metadata<br/>document.ocrProcessed = true<br/>ocr_jobs.status = completed"]:::writeNode
+
+        FINWRITE ==>|"SEARCHABLE — this is 'done' for the user"| DONE(("Document usable")):::terminal
+
+        FINWRITE --> GRAPH["F · GraphRAG extract<br/>(entities + relationships, one step)"]:::failsoft
+        GRAPH --> GRAPHWRITE["writes: Postgres kg_entities,<br/>kg_entity_mentions, kg_relationships<br/>(graph source of truth)"]:::writeNode
+        GRAPHWRITE --> NEO["G · Neo4j sync"]:::failsoft
+        NEO --> NEOWRITE["writes: Neo4j :Entity / :Section + edges<br/>mirror only — full text stays in Postgres<br/>⚠ can silently stay empty on a 'completed' doc"]:::writeNode
+
+        FINWRITE -.->|"always fires"| COMPANY["Downstream job:<br/>company-metadata/extract"]
+        FINWRITE -.->|"only if versionId (re-upload)"| REHYDRATE["Downstream job:<br/>notes-anchors/rehydrate"]
+    end
+
+    subgraph EXT["External dependencies touched"]
+        direction LR
+        PG[("Postgres + pgvector")]:::external
+        ING[/"Inngest — retries:5, concurrency:3,<br/>throttle:30/min, timeout:120m"/]:::external
+        OS[("Object storage — S3 or DB")]:::external
+        OCRP[/"OCR providers"/]:::external
+        N4J[("Neo4j — mirror only")]:::external
+        SC[/"sidecar/ folder — DOCX + Whisper only<br/>≠ SIDECAR_URL ML worker"/]:::external
+    end
+
+    U -.-> OS
+    DISP -.-> ING
+    OCR -.-> OCRP
+    REC -.-> PG
+    OCRWRITE -.-> PG
+    CHUNKWRITE -.-> PG
+    EMBEDWRITE -.-> PG
+    FINWRITE -.-> PG
+    GRAPHWRITE -.-> PG
+    NEOWRITE -.-> N4J
+
+    classDef failhard fill:#7f1d1d,stroke:#f87171,color:#fff,stroke-width:2px
+    classDef failsoft fill:#78350f,stroke:#fbbf24,color:#fff,stroke-width:2px
+    classDef writeNode fill:#1e293b,stroke:#64748b,color:#e2e8f0,stroke-dasharray: 3 3
+    classDef external fill:#0f172a,stroke:#38bdf8,color:#7dd3fc,stroke-dasharray: 2 2
+    classDef terminal fill:#14532d,stroke:#4ade80,color:#fff,stroke-width:2px
+    classDef failure fill:#450a0a,stroke:#ef4444,color:#fecaca,stroke-dasharray: 4 2
+
+```

--- a/docs/pipeline/pipeline-diagram.mmd
+++ b/docs/pipeline/pipeline-diagram.mmd
@@ -1,6 +1,4 @@
 ```mermaid
-
-%%{init: {'theme': 'dark', 'themeVariables': {'fontSize': '14px'}}}%%
 flowchart TD
 
     subgraph LEGEND["Legend"]
@@ -8,67 +6,55 @@ flowchart TD
         L1["Fail-hard stage<br/>(5 retries → stuck)"]:::failhard
         L2["Fail-soft stage<br/>(silent, optional)"]:::failsoft
         L3["Persisted write"]:::writeNode
-        L4["External dependency"]:::external
+        L4["External dependency<br/>(placed next to where it's used)"]:::external
         L5["User-facing done"]:::terminal
     end
 
-    subgraph MAIN["Document Ingestion Pipeline — Stages A→G"]
-        direction TB
+    U["HTTP Upload"] --> OS[("Object storage<br/>S3 or DB · via storage.ts")]:::external
+    U --> REC["document + document_versions created<br/>ocr_jobs.status = queued"]:::writeNode
+    REC -.-> PG0[("Postgres + pgvector")]:::external
 
-        U["HTTP Upload"] --> REC["document + document_versions created<br/>ocr_jobs.status = queued"]:::writeNode
-        REC --> DISP["Inngest event fired:<br/>document/process.requested"]
-        DISP --> ROUTE{"A · Route by file type"}
+    REC --> DISP["Inngest event fired:<br/>document/process.requested"]
+    DISP -.-> ING[/"Inngest — retries:5, concurrency:3,<br/>throttle:30/min, timeout:120m"/]:::external
+    DISP --> ROUTE{"A · Route by file type"}
 
-        ROUTE -->|"ZIP"| ZIP["Extract entries (≤500 files, ≤10MB each)<br/>insert child docs + child ocr_jobs<br/>fan out in batches of 10<br/>delete original ZIP doc"]
-        ZIP -.->|"re-dispatch per child"| DISP
+    ROUTE -->|"ZIP"| ZIP["Extract entries (≤500 files, ≤10MB each)<br/>insert child docs + child ocr_jobs<br/>fan out in batches of 10<br/>delete original ZIP doc<br/>⚠ child files bypass storage.ts,<br/>write directly to Vercel Blob"]
+    ZIP -.->|"re-dispatch per child"| DISP
 
-        ROUTE -->|"text / code"| FAST["Fast path — OCR skipped entirely"]
-        ROUTE -->|"everything else"| OCR["B · Normalize / OCR<br/>Azure · Landing.AI · Datalab · OSS · pdfjs<br/>(+ optional VLM enrichment)"]:::failhard
+    ROUTE -->|"text / code"| FAST["Fast path — OCR skipped entirely"]
+    ROUTE -->|"everything else"| OCR["B · Normalize / OCR<br/>Azure · Landing.AI · Datalab · OSS · pdfjs<br/>(+ optional VLM enrichment)<br/>⚙ Azure PDFs: 2 steps (a-router + b-normalize)<br/>⚙ everything else: 1 combined step (ab-ingest)"]:::failhard
+    OCR -.-> OCRP[/"OCR providers"/]:::external
 
-        OCR --> OCRWRITE["writes: pages → ocr_jobs.ocrResult"]:::writeNode
-        OCR -.->|"fails all 5 retries"| FAIL["ocr_jobs.status stays 'queued' — forever<br/>onFailure → document.ocrProcessed = true<br/>ocrMetadata.error = 'processing_failed'<br/>⚠ looks identical to a doc still in progress"]:::failure
+    OCR --> OCRWRITE["writes: pages → ocr_jobs.ocrResult"]:::writeNode
+    OCRWRITE -.-> PG1[("Postgres")]:::external
+    OCR -.->|"fails all 5 retries"| FAIL["ocr_jobs.status stays 'queued' — forever<br/>onFailure → document.ocrProcessed = true<br/>ocrMetadata.error = 'processing_failed'<br/>⚠ looks identical to a doc still in progress"]:::failure
 
-        FAST --> CHUNK
-        OCRWRITE --> CHUNK["C · Chunk<br/>(parent/child text units)"]:::failhard
-        CHUNK --> CHUNKWRITE["writes: chunks → ocr_jobs.ocrResult"]:::writeNode
+    FAST --> CHUNK
+    OCRWRITE --> CHUNK["C · Chunk<br/>(parent/child text units)"]:::failhard
+    CHUNK --> CHUNKWRITE["writes: chunks → ocr_jobs.ocrResult"]:::writeNode
+    CHUNKWRITE -.-> PG2[("Postgres")]:::external
 
-        CHUNKWRITE --> EMBED["D · Embed + Store<br/>OpenAI (1536-dim) or sidecar /embed"]:::failhard
-        EMBED --> EMBEDWRITE["writes: document_structure,<br/>document_context_chunks,<br/>document_retrieval_chunks (vector 1536 + short 512)"]:::writeNode
+    CHUNKWRITE --> EMBED["D · Embed + Store<br/>OpenAI (1536-dim) or sidecar /embed"]:::failhard
+    EMBED -.-> SC[/"sidecar/ folder is DOCX + Whisper only<br/>≠ the SIDECAR_URL ML worker used here"/]:::external
+    EMBED --> EMBEDWRITE["writes: document_structure,<br/>document_context_chunks,<br/>document_retrieval_chunks (vector 1536 + short 512)"]:::writeNode
+    EMBEDWRITE -.-> PG3[("Postgres")]:::external
 
-        EMBEDWRITE --> FIN["E · Finalize"]:::failhard
-        FIN --> FINWRITE["writes: document_metadata<br/>document.ocrProcessed = true<br/>ocr_jobs.status = completed"]:::writeNode
+    EMBEDWRITE --> FIN["E · Finalize"]:::failhard
+    FIN --> FINWRITE["writes: document_metadata<br/>document.ocrProcessed = true<br/>ocr_jobs.status = completed"]:::writeNode
+    FINWRITE -.-> PG4[("Postgres")]:::external
 
-        FINWRITE ==>|"SEARCHABLE — this is 'done' for the user"| DONE(("Document usable")):::terminal
+    FINWRITE ==>|"SEARCHABLE — this is 'done' for the user"| DONE(("Document usable")):::terminal
 
-        FINWRITE --> GRAPH["F · GraphRAG extract<br/>(entities + relationships, one step)"]:::failsoft
-        GRAPH --> GRAPHWRITE["writes: Postgres kg_entities,<br/>kg_entity_mentions, kg_relationships<br/>(graph source of truth)"]:::writeNode
-        GRAPHWRITE --> NEO["G · Neo4j sync"]:::failsoft
-        NEO --> NEOWRITE["writes: Neo4j :Entity / :Section + edges<br/>mirror only — full text stays in Postgres<br/>⚠ can silently stay empty on a 'completed' doc"]:::writeNode
+    FINWRITE --> GRAPH["F · GraphRAG extract<br/>(entities + relationships, one step)"]:::failsoft
+    GRAPH --> GRAPHWRITE["writes: Postgres kg_entities,<br/>kg_entity_mentions, kg_relationships<br/>(graph source of truth)"]:::writeNode
+    GRAPHWRITE -.-> PG5[("Postgres")]:::external
 
-        FINWRITE -.->|"always fires"| COMPANY["Downstream job:<br/>company-metadata/extract"]
-        FINWRITE -.->|"only if versionId (re-upload)"| REHYDRATE["Downstream job:<br/>notes-anchors/rehydrate"]
-    end
+    GRAPHWRITE --> NEO["G · Neo4j sync"]:::failsoft
+    NEO --> NEOWRITE["writes: Neo4j :Entity / :Section + edges<br/>mirror only — full text stays in Postgres<br/>⚠ can silently stay empty on a 'completed' doc"]:::writeNode
+    NEOWRITE -.-> N4J[("Neo4j — mirror only")]:::external
 
-    subgraph EXT["External dependencies touched"]
-        direction LR
-        PG[("Postgres + pgvector")]:::external
-        ING[/"Inngest — retries:5, concurrency:3,<br/>throttle:30/min, timeout:120m"/]:::external
-        OS[("Object storage — S3 or DB")]:::external
-        OCRP[/"OCR providers"/]:::external
-        N4J[("Neo4j — mirror only")]:::external
-        SC[/"sidecar/ folder — DOCX + Whisper only<br/>≠ SIDECAR_URL ML worker"/]:::external
-    end
-
-    U -.-> OS
-    DISP -.-> ING
-    OCR -.-> OCRP
-    REC -.-> PG
-    OCRWRITE -.-> PG
-    CHUNKWRITE -.-> PG
-    EMBEDWRITE -.-> PG
-    FINWRITE -.-> PG
-    GRAPHWRITE -.-> PG
-    NEOWRITE -.-> N4J
+    FINWRITE -.->|"always fires"| COMPANY["Downstream job:<br/>company-metadata/extract"]
+    FINWRITE -.->|"only if versionId (re-upload)"| REHYDRATE["Downstream job:<br/>notes-anchors/rehydrate"]
 
     classDef failhard fill:#7f1d1d,stroke:#f87171,color:#fff,stroke-width:2px
     classDef failsoft fill:#78350f,stroke:#fbbf24,color:#fff,stroke-width:2px
@@ -76,5 +62,4 @@ flowchart TD
     classDef external fill:#0f172a,stroke:#38bdf8,color:#7dd3fc,stroke-dasharray: 2 2
     classDef terminal fill:#14532d,stroke:#4ade80,color:#fff,stroke-width:2px
     classDef failure fill:#450a0a,stroke:#ef4444,color:#fecaca,stroke-dasharray: 4 2
-
 ```

--- a/docs/pipeline/pipeline-diagram.mmd
+++ b/docs/pipeline/pipeline-diagram.mmd
@@ -1,4 +1,4 @@
-```mermaid
+
 flowchart TD
 
     subgraph LEGEND["Legend"]
@@ -62,4 +62,3 @@ flowchart TD
     classDef external fill:#0f172a,stroke:#38bdf8,color:#7dd3fc,stroke-dasharray: 2 2
     classDef terminal fill:#14532d,stroke:#4ade80,color:#fff,stroke-width:2px
     classDef failure fill:#450a0a,stroke:#ef4444,color:#fecaca,stroke-dasharray: 4 2
-```

--- a/docs/pipeline/pipeline-failure-matrix.md
+++ b/docs/pipeline/pipeline-failure-matrix.md
@@ -37,6 +37,14 @@ Detail cards also record **What happens**, **Left behind** (state + how you’d 
 | [U8](#u8) | Upload / dispatch | Inngest + Postgres        | Event dispatched before / without durable `ocr_jobs` row  | Needs fix (High)    |
 | [U9](#u9) | Upload / dispatch | Postgres + Inngest        | Client retry or concurrent upload creates duplicate trees | Needs discussion    |
 
+| ID        | Stage             | Dependency                | Failure mode                                              | Status              |
+| --------- | ----------------- | ------------------------- | --------------------------------------------------------- | ------------------- |
+| [D1](#u1) | Embed / Store |               |                   |  |
+| [D2](#u2) | Embed / Store |                          |                 |  |
+| [D3](#u3) | Embed / Store |                  |         |  |
+| [D4](#u4) | Embed / Store |        |                 |      |
+| [D5](#u5) | Embed / Store |      |           |     |
+
 
 ---
 

--- a/docs/pipeline/pipeline-failure-matrix.md
+++ b/docs/pipeline/pipeline-failure-matrix.md
@@ -37,6 +37,31 @@ Detail cards also record **What happens**, **Left behind** (state + how you’d 
 | [U8](#u8) | Upload / dispatch | Inngest + Postgres        | Event dispatched before / without durable `ocr_jobs` row  | Needs fix (High)    |
 | [U9](#u9) | Upload / dispatch | Postgres + Inngest        | Client retry or concurrent upload creates duplicate trees | Needs discussion    |
 
+
+| ID        | Stage | Dependency                | Failure mode                                                    | Status                   |
+| --------- | ----- | -------------------------- | ----------------------------------------------------------------- | ------------------------- |
+| [A1](#a1) | Route | ocr-router sidecar (external) | Sidecar unreachable/non-200 → silent fallback provider, `pageCount` forced to `0` | Needs fix (Medium-High)   |
+| [A2](#a2) | Route | Object storage + `pdf-lib`  | `getPageCount` fails, silently defaults to page count `1`         | Needs discussion (Low)    |
+| [A3](#a3) | Route | —                           | Invalid/unrecognized `preferredProvider` silently ignored, falls back to auto-detection | Working as intended       |
+
+
+| ID        | Stage            | Dependency                         | Failure mode                                                                                  | Status            |
+| --------- | ---------------- | ----------------------------------- | ------------------------------------------------------------------------------------------------ | ------------------ |
+| [B1](#b1) | OCR / Normalize  | Object storage + `pdfjs-serverless` | `processNativePDF` throws on storage-download failure or corrupted/unparseable PDF               | Needs fix (High)   |
+| [B2](#b2) | OCR / Normalize  | Object storage (HEAD request)       | Content-type sniffing for non-`.pdf`-named URLs fails silently                                    | Needs discussion (Low) |
+| [B3](#b3) | OCR / Normalize  | —                                    | Unrecognized `selectedProvider` silently falls back to native PDF extraction                      | Working as intended |
+| [B4](#b4) | OCR / Normalize  | Azure Document Intelligence (external) | 5 unhandled throw points + 120s poll timeout                                                   | Needs fix (High)   |
+| [B5](#b5) | OCR / Normalize  | ocr-worker service (self-hosted)    | Unreachable, 10-min timeout, or non-200 response                                                  | Needs fix (High)   |
+
+
+| ID        | Stage | Dependency                     | Failure mode                                                                 | Status                      |
+| --------- | ----- | -------------------------------- | -------------------------------------------------------------------------------- | ----------------------------- |
+| [C1](#c1) | Chunk | —                                 | `chunkDocument` / `chunkCodeFile` throws on malformed or unexpected page content | Needs fix (High)              |
+| [C2](#c2) | Chunk | Postgres                         | `loadPipelineState` throws when `"pages"` key is missing from `ocr_jobs.ocrResult` | Needs discussion (Low probability) |
+| [C3](#c3) | Chunk | Postgres                         | `savePipelineState`'s read-then-write on `ocrResult` is not atomic               | Needs discussion              |
+| [C4](#c4) | Chunk | OpenAI (via `getOpenAIClient`)   | Table-description LLM call fails or is unconfigured                              | Working as intended           |
+
+
 | ID        | Stage             | Dependency                | Failure mode                                              | Status              |
 | --------- | ----------------- | ------------------------- | --------------------------------------------------------- | ------------------- |
 | [D1](#u1) | Embed / Store | Embedding Provider (OpenAI or external sidecar `/embed`)              |                   |  |
@@ -140,3 +165,93 @@ Detail cards also record **What happens**, **Left behind** (state + how you’d 
 - **Left behind:** Duplicate document trees; file processed 2× (double work/credits). Silent — no constraint violation.
 - **Notes:** Re-upload may be intended product behavior. Sharp case: [U7](#u7) 500 after commit → client retry → duplicates. Concurrent same-file uploads don’t collide on `versionNumber=1` because each gets a distinct `documentId`.
 
+### A1
+Sidecar unreachable/non-200 → silent fallback provider, `pageCount` forced to `0` · ocr-router sidecar (external) · Needs fix (Medium-High)
+
+* What happens: `determineDocumentRouting` (`[complexity.ts:L?]`) wraps its sidecar call in its own try/catch. On any failure it logs a warning and returns a synthetic fallback: a static provider from `getDefaultOCRProvider()` (env-config only, no document inspection), `confidence: 0.5`, `pageCount: 0`. Never throws to its caller.
+* Left behind: No error surfaces anywhere except a log line. Routing quality silently degrades (no vision-based complexity detection) for every document processed during an outage. `pageCount: 0` flows into `createRootStructure`'s `endPage` field downstream.
+* Notes: Opposite failure shape from the fail-hard stages — degrades silently instead of getting stuck. Worth discussing whether `pageCount: 0` was intentional and whether degraded routing should be surfaced somewhere.
+
+### A2
+`getPageCount` fails, silently defaults to page count `1` · Object storage + pdf-lib · Needs discussion (Low)
+
+* What happens: `getPageCount` (`[processor.ts:L?]`) wraps the PDF page-count read in try/catch. On failure, logs a warning and returns `1`. Only runs on the explicit `preferredProvider` branch of `routeDocument`.
+* Left behind: No error surfaces; a document with any real page count could get silently recorded with `totalPages: 1` downstream.
+* Notes: Low severity alone, but a silent data-correctness gap. Worth confirming whether wrong page counts affect anything downstream (search, UI, credit calculations).
+
+### A3
+Invalid/unrecognized `preferredProvider` value silently ignored, falls back to auto-detection · — · Working as intended
+
+* What happens: `routeDocument`'s entry check (`preferred === "NATIVE_PDF" || isValidOCRProvider(preferred)`) simply evaluates false for a bad value and falls through to auto-detection — no error, no warning.
+* Left behind: Caller gets no feedback that their explicit preference was ignored.
+* Notes: Likely fine as-is, but worth flagging since a typo'd provider name fails completely silently.
+
+### B1
+`processNativePDF` throws on storage-download failure or corrupted/unparseable PDF · Object storage + pdfjs-serverless · Needs fix (High)
+
+* What happens: No error handling anywhere in `processNativePDF` (`[processor.ts:L?]`). Failed download throws explicitly; malformed PDF causes `pdfjs-serverless`'s `getDocument(...).promise` to reject. Propagates unhandled to the outer pipeline catch → Inngest retry (5×) → `onFailure`.
+* Left behind: `ocr_jobs.status` stuck at `queued`; `document.ocrProcessed` incorrectly set `true` after retries exhaust; real error only in `ocrMetadata`.
+* Notes: Also reachable indirectly via the provider-switch `default` case (unrecognized provider falls back to `processNativePDF`), which could hit this on non-PDF content. Cross-reference with B3.
+
+### B2
+Content-type sniffing for non-`.pdf`-named URLs fails silently · Object storage (HEAD request) · Needs discussion (Low)
+
+* What happens: `normalizeDocument`'s `isPdf` check falls back to `.catch(() => false)` on a HEAD request if the URL doesn't literally end in `.pdf`.
+* Left behind: A real PDF served without a `.pdf` extension could silently lose VLM-enrichment eligibility if the HEAD check fails.
+* Notes: Low stakes since VLM enrichment is already optional.
+
+### B3
+Unrecognized `selectedProvider` silently falls back to native PDF extraction · — · Working as intended
+
+* What happens: `normalizeDocument`'s provider `switch` default case logs a warning and calls `processNativePDF` regardless of actual file type.
+* Left behind: Could cascade into B1 if the content isn't actually a valid PDF.
+* Notes: Cross-reference with B1.
+
+### B4
+Azure Document Intelligence adapter fails: missing credentials, fetch-document failure, submit failure, poll failure, or 120s poll timeout · Azure Document Intelligence (external) · Needs fix (High)
+
+* What happens: `AzureDocumentIntelligenceAdapter` (`[azureAdapter.ts:L?]`) throws unhandled at five distinct points — none locally caught. Includes a manual 60-poll × 2s (120s total) timeout that throws if Azure never resolves.
+* Left behind: Same "queued forever" signature as B1.
+* Notes: Two stacked timeout layers — Azure's own 120s internal timeout vs. Inngest's 120-minute function timeout. Worth checking whether re-polling for 120s on each of 5 Inngest retries is an efficient use of the retry budget.
+
+### B5
+Self-hosted OCR worker (Marker/Docling) unreachable, times out (10 min), or returns non-200 · ocr-worker service (self-hosted) · Needs fix (High)
+
+* What happens: `OssOCRAdapter.uploadDocument` (`[ossAdapter.ts:L?]`) wraps fetch in try/catch; network failure or the 10-minute `AbortController` timeout throws a rewrapped error; non-OK response also throws. Nothing swallowed.
+* Left behind: Same signature as B1/B4.
+* Notes: Third provider implementation confirming the same fail-hard shape across native PDF, Azure, and OSS worker. Landing.AI/Datalab assumed consistent but not independently verified.
+
+### X1
+`MARKER` provider is dead code / mislabeled as `DOCLING` · — · Needs fix (Medium — correctness bug)
+
+* What happens: `processor.ts`'s provider switch routes both `"MARKER"` and `"DOCLING"` cases to `processWithDocling`; separately, `createMarkerAdapter` in `ossAdapter.ts` hardcodes `"DOCLING"` regardless of intent.
+* Left behind: No crash — any document routed to "MARKER" is silently processed via Docling instead. Invisible without reading source.
+* Notes: Not a failure/retry issue — a genuine functional bug found while tracing. Flag to whoever owns OCR provider config.
+
+### C1
+`chunkDocument` / `chunkCodeFile` throws on malformed or unexpected page content · — · Needs fix (High)
+
+* What happens: No error handling in `chunkPages` or `chunkDocument`. Any throw propagates to `step-c-chunking` → outer catch → Inngest retry cycle.
+* Left behind: Same "queued forever" signature.
+* Notes: Exact trigger conditions unverified — would need deeper read of edge cases in `chunker.ts`/`code-chunker.ts`.
+
+### C2
+`loadPipelineState` throws when `"pages"` key is missing from `ocr_jobs.ocrResult` · Postgres · Needs discussion (Low probability)
+
+* What happens: Explicit, deliberate throw if the expected state key isn't present. Not retried by `withDbRetry` (not a transient DB error) — only Inngest's step retry governs recovery.
+* Left behind: Same fail-hard signature if retries exhaust; unlikely in practice given sequential step execution.
+* Notes: Confirm with the team whether any realistic scenario (replay, race, manual re-trigger) could actually hit this.
+
+### C3
+`savePipelineState`'s read-then-write on `ocrResult` is not atomic · Postgres · Needs discussion
+
+* What happens: Reads current JSON blob, merges new key locally, writes whole object back — a classic lost-update race if ever concurrent.
+* Left behind: Unlikely under normal sequential Inngest execution; latent risk rather than confirmed bug.
+* Notes: Worth discussing given it sits in some tension with the architecture doc's idempotency claims.
+
+### C4
+Table-description LLM call fails or is unconfigured · OpenAI (via getOpenAIClient) · Working as intended
+
+* What happens: `generateTableDescription` computes a rule-based fallback first, then wraps the optional OpenAI call in try/catch; any failure or missing config falls back cleanly.
+* Left behind: Nothing — chunking proceeds with a less-polished but usable description.
+* Notes: Good positive example of deliberate fail-soft design, worth citing in review. One unverified loose thread: `getOpenAI()` is called outside the try block — if `getOpenAIClient()` can itself throw rather than return `null`, that path is unprotected.

--- a/docs/pipeline/pipeline-failure-matrix.md
+++ b/docs/pipeline/pipeline-failure-matrix.md
@@ -64,26 +64,26 @@ Detail cards also record **What happens**, **Left behind** (state + how you’d 
 
 | ID        | Stage             | Dependency                | Failure mode                                              | Status              |
 | --------- | ----------------- | ------------------------- | --------------------------------------------------------- | ------------------- |
-| [D1](#u1) | Embed / Store | Embedding Provider (OpenAI or external sidecar `/embed`)              |                   |  |
-| [D2](#u2) | Embed / Store | Postgres + pgvector (`storeBatch`)                         |                 |  |
-| [D3](#u3) | Embed / Store | Postgres structure/metadata writes                 |         |  |
+| [D1](#d1) | Embed / Store | Embedding Provider (OpenAI or external sidecar `/embed`)              |   Embedding call fails in embedDocuments/embedQuery during step-d-batch-*                | Needs fix (high) |
+| [D2](#d2) | Embed / Store | Postgres + pgvector (`storeBatch`)                         |    Batch write fails after vectors computed; pipeline retries whole run             | Needs Discussion |
+| [D3](#d3) | Embed / Store | Postgres (`documentContextChunks` readback)                 |  Readback query fails or returns partial set used for downstream GraphRAG       | Needs Discussion |
 
 | ID        | Stage             | Dependency                | Failure mode                                              | Status              |
 | --------- | ----------------- | ------------------------- | --------------------------------------------------------- | ------------------- |
-| [E1](#u1) | Finalize | Postgres finalize path (`finalizeStorage`)              |                   |  |
-| [E2](#u2) | Finalize | Status model (`onFailure` + runtime flags)                         |                 |  |
-
-
-| ID        | Stage             | Dependency                | Failure mode                                              | Status              |
-| --------- | ----------------- | ------------------------- | --------------------------------------------------------- | ------------------- |
-| [F1](#u1) | GraphRAG | External sidecar health (`SIDECAR_URL/health`)              |                   |  |
-| [F2](#u2) | GraphRAG | Entity extraction + Postgres `kg_*` writes                         |                 |  |
+| [E1](#e1) | Finalize | Postgres finalize path (`finalizeStorage`)              |  Finalize throws after successful embed/store                 | Needs fix (high) |
+| [E2](#e2) | Finalize | Failure/status model (`markFailureInDb`, Inngest retry semantics)                         |   Non-Inngest path can return failure result without DB failure mark unless flag enabled              | Needs Discussion |
 
 
 | ID        | Stage             | Dependency                | Failure mode                                              | Status              |
 | --------- | ----------------- | ------------------------- | --------------------------------------------------------- | ------------------- |
-| [G1](#u1) | Neo4j | Neo4j availability/config (`NEO4J_URI`, config, health)              |                   |  |
-| [G2](#u2) | Neo4j | Neo4j write operation (`syncDocumentToNeo4j`)                         |                 |  |
+| [F1](#f1) | GraphRAG | External sidecar health (`SIDECAR_URL/health`)              |   Sidecar unhealthy causes silent skip of entity extraction                | Needs Discussion |
+| [F2](#f2) | GraphRAG | Entity extraction + Postgres `kg_*` writes                         | `extractAndStoreEntities` throws; optional stage fails hard and can fail whole ingestion                | Needs fix (Medium-High) |
+
+
+| ID        | Stage             | Dependency                | Failure mode                                              | Status              |
+| --------- | ----------------- | ------------------------- | --------------------------------------------------------- | ------------------- |
+| [G1](#g1) | Neo4j | Neo4j availability/config (`NEO4J_URI`, config, health)              |   Neo4j absent/unconfigured/unhealthy silently skips sync                | Working as intended |
+| [G2](#g2) | Neo4j | Neo4j write operation (`syncDocumentToNeo4j`)                         |    Sync throws and fails whole pipeline after finalize             | Needs Discussion |
 
 ---
 
@@ -255,3 +255,58 @@ Table-description LLM call fails or is unconfigured · OpenAI (via getOpenAIClie
 * What happens: `generateTableDescription` computes a rule-based fallback first, then wraps the optional OpenAI call in try/catch; any failure or missing config falls back cleanly.
 * Left behind: Nothing — chunking proceeds with a less-polished but usable description.
 * Notes: Good positive example of deliberate fail-soft design, worth citing in review. One unverified loose thread: `getOpenAI()` is called outside the try block — if `getOpenAIClient()` can itself throw rather than return `null`, that path is unprotected.
+
+### D1
+Embedding provider call fails during vectorization · Embedding provider (OpenAI or external index backend) · Needs fix (High)
+
+* What happens: In `vectorizeWithIndex`, each `step-d-batch-*` calls `embeddings.embedDocuments?.(...) ?? Promise.all(...embedQuery...)`. Any throw bubbles up and fails the ingestion run.
+* Left behind: `rootStructure` may already exist from `step-d-setup`; some earlier batches may already be stored, later ones not. On retry, duplicate/partial-write behavior depends on `storeBatch` idempotency (not enforced in this file).
+* Notes: Failure occurs after chunking, so retries can re-run expensive work.
+### D2
+`storeBatch` write failure after successful embedding for a batch · Postgres + pgvector (`storeBatch`) · Needs discussion
+
+* What happens: A batch can successfully produce vectors, then fail on `storeBatch(...)`, causing step failure.
+* Left behind: Prior batches may already be committed; current/remaining batches missing. Retry may re-embed and may duplicate previous rows if no uniqueness/idempotency guard exists in storage layer.
+* Notes: Consider per-batch idempotency key or deterministic upsert key to make retries safe.
+### D3
+Post-store readback for `storedSections` fails or is inconsistent · Postgres (`documentContextChunks`) · Needs discussion
+
+* What happens: After all batches, code re-queries `documentContextChunks` by `documentId` to build `storedSections` for Step F. Query failure throws.
+* Left behind: Embeddings may already be persisted; GraphRAG input construction fails, causing pipeline failure despite successful storage.
+* Notes: This tight coupling means optional Step F depends on a full readback of D outputs.
+### E1
+`finalizeStorage` fails after successful D writes · Postgres finalize path (`finalizeStorage`) · Needs fix (High)
+
+* What happens: `step-e-finalize` runs after D and can throw.
+* Left behind: Chunks/embeddings may already be stored, but document/job final status/metadata may remain unfinalized. On retry, duplicate finalize side effects depend on finalize idempotency.
+* Notes: Classic late-stage commit gap; worth ensuring finalize is idempotent and safely retryable.
+### E2
+Failure marking is runtime-flag dependent and can be skipped · Failure/status model (`markFailureInDb`, Inngest/runtime flags) · Needs discussion
+
+* What happens: In catch, DB failure mark happens only if `markFailureInDb` is true. Otherwise, non-Inngest path returns failure payload without status update in DB.
+* Left behind: Potential mismatch between returned failure and persisted job status.
+* Notes: Verify all production invocations set `markFailureInDb` as intended.
+### F1
+GraphRAG skipped when sidecar health check fails · Sidecar health (`SIDECAR_URL/health`) · Needs discussion
+
+* What happens: If `sidecarUrl` is set and `/health` is non-OK/unreachable, step F logs warning and returns (no throw).
+* Left behind: Ingestion succeeds without entity/relationship extraction; silent feature degradation except logs.
+* Notes: This is deliberate fail-soft behavior.
+### F2
+Entity extraction/write throws and fails whole ingestion · Entity extraction + Postgres `kg_*` writes · Needs fix (Medium-High)
+
+* What happens: Inside `step-f-graph-rag`, `extractAndStoreEntities(...)` exceptions are uncaught locally and bubble out.
+* Left behind: Core ingestion already finalized (E done), but optional graph stage failure can still fail the whole run.
+* Notes: Design tension: F is optional conceptually, fail-hard operationally.
+### G1
+Neo4j missing/unconfigured/unhealthy causes sync skip · Neo4j availability/config/health · Working as intended
+
+* What happens: If no `NEO4J_URI`, returns early. If `isNeo4jConfigured()` false or health check fails, logs warning and skips.
+* Left behind: Ingestion success with no Neo4j projection.
+* Notes: Explicit fail-soft design.
+### G2
+`syncDocumentToNeo4j` throw fails ingestion after finalize · Neo4j write operation (`syncDocumentToNeo4j`) · Needs discussion
+
+* What happens: `step-g-neo4j-sync` has no local try/catch around `syncDocumentToNeo4j`; throw bubbles and fails run.
+* Left behind: E and likely F may already be committed; Neo4j projection missing; overall run may still be marked failed depending on runtime flags.
+* Notes: Similar tension as F2; consider making G fail-soft like G1 health gating.

--- a/docs/pipeline/pipeline-failure-matrix.md
+++ b/docs/pipeline/pipeline-failure-matrix.md
@@ -39,11 +39,9 @@ Detail cards also record **What happens**, **Left behind** (state + how you’d 
 
 | ID        | Stage             | Dependency                | Failure mode                                              | Status              |
 | --------- | ----------------- | ------------------------- | --------------------------------------------------------- | ------------------- |
-| [D1](#u1) | Embed / Store | Embedding Provider (OpenAI or external sidecar /embed)              |                   |  |
-| [D2](#u2) | Embed / Store |                          |                 |  |
-| [D3](#u3) | Embed / Store |                  |         |  |
-| [D4](#u4) | Embed / Store |        |                 |      |
-| [D5](#u5) | Embed / Store |      |           |     |
+| [D1](#u1) | Embed / Store | Embedding Provider (OpenAI or external sidecar `/embed`)              |                   |  |
+| [D2](#u2) | Embed / Store | Postgres + pgvector (`storeBatch`)                         |                 |  |
+| [D3](#u3) | Embed / Store | Postgres structure/metadat writes                 |         |  |
 
 | ID        | Stage             | Dependency                | Failure mode                                              | Status              |
 | --------- | ----------------- | ------------------------- | --------------------------------------------------------- | ------------------- |

--- a/docs/pipeline/pipeline-failure-matrix.md
+++ b/docs/pipeline/pipeline-failure-matrix.md
@@ -1,0 +1,120 @@
+# Pipeline Failure Matrix
+
+> Companion to `[pipeline-architecture.md](./pipeline-architecture.md)`.
+> Stage names match that doc. Cite failures by stable ID (e.g. `U7`) in tickets/PRs.
+
+**How to use:** skim the [Index](#index) for backlog (filter **Needs fix**). Open a detail card for mechanics and left-behind state.
+
+---
+
+## Conventions
+
+
+| Field            | Meaning                                                                                                                                                                                                              |
+| ---------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **ID**           | Stable prefix + number. Prefixes: `U` Upload/dispatch · `A` Route · `B` OCR · `C` Chunk · `D` Embed/store · `E` Finalize · `F` GraphRAG · `G` Neo4j · `M` Company metadata · `N` Notes rehydrate · `X` Cross-cutting |
+| **Dependency**   | External system involved, or `—` if in-process                                                                                                                                                                       |
+| **Failure mode** | One concrete scenario (not a category)                                                                                                                                                                               |
+| **Status**       | **Working as intended** · **Needs fix (High|Mid|Low)** · **Needs discussion**                                                                                                                                        |
+
+
+Detail cards also record **What happens**, **Left behind** (state + how you’d notice), and **Notes**.
+
+---
+
+## Index
+
+
+| ID        | Stage             | Dependency                | Failure mode                                              | Status              |
+| --------- | ----------------- | ------------------------- | --------------------------------------------------------- | ------------------- |
+| [U1](#u1) | Upload / dispatch | Rate limiter              | Caller exceeds `RateLimitPresets.strict`                  | Working as intended |
+| [U2](#u2) | Upload / dispatch | —                         | Malformed JSON or missing required fields                 | Working as intended |
+| [U3](#u3) | Upload / dispatch | Postgres                  | `userId` not found / active-company resolve errors        | Working as intended |
+| [U4](#u4) | Upload / dispatch | Postgres (credits)        | Insufficient credits masked as generic 500                | Needs fix (Low)     |
+| [U5](#u5) | Upload / dispatch | Object storage + Postgres | `document` insert fails; upstream blob orphaned           | Needs discussion    |
+| [U6](#u6) | Upload / dispatch | Postgres                  | `createInitialVersion` fails after `document` committed   | Needs fix (Mid)     |
+| [U7](#u7) | Upload / dispatch | Inngest                   | Dispatch throws after `document`+version committed        | Needs fix (High)    |
+| [U8](#u8) | Upload / dispatch | Inngest + Postgres        | Event dispatched before / without durable `ocr_jobs` row  | Needs fix (High)    |
+| [U9](#u9) | Upload / dispatch | Postgres + Inngest        | Client retry or concurrent upload creates duplicate trees | Needs discussion    |
+
+
+---
+
+## Upload / dispatch
+
+> Scope: `POST /api/uploadDocument` → validation → `document` / `document_versions` / `ocr_jobs` → Inngest event. Stops at handoff to Step A.
+>
+> **Structural note:** all three DB writes run in the HTTP handler **before** `process-document`, so they are **not** in `step.run` (no Inngest memoization). No transaction spans the three tables: `document` insert (`[create-document.ts:29](../../apps/web/src/server/services/create-document.ts#L29)`), then `document_versions` + `currentVersionId` (`[document-upload.ts:88](../../apps/web/src/server/services/document-upload.ts#L88)`), then `ocr_jobs` (`[trigger-job.ts:50](../../apps/web/src/server/services/trigger-job.ts#L50)`). The event is dispatched **before** the `ocr_jobs` insert (`[trigger.ts:92](../../packages/core/src/ocr/trigger.ts#L92)`).
+
+### U1
+
+**Caller exceeds `RateLimitPresets.strict`** · Rate limiter · Working as intended
+
+- **What happens:** `withRateLimit` returns 429 + `Retry-After` before the handler body (`[rate-limit-middleware.ts:60](../../apps/web/src/lib/rate-limit-middleware.ts#L60)`).
+- **Left behind:** Nothing. Loud 429 to caller.
+- **Notes:** Limiter is in-memory; multi-instance behavior not verified.
+
+### U2
+
+**Malformed JSON or missing/blank `userId` / `documentUrl` / `documentName`** · — · Working as intended
+
+- **What happens:** `validateRequestBody` returns 400 before any write (`[route.ts:45](../../apps/web/src/app/api/uploadDocument/route.ts#L45)`).
+- **Left behind:** Nothing. Loud 400 with field detail.
+- **Notes:** Route uses an inline Zod schema (`[route.ts:24](../../apps/web/src/app/api/uploadDocument/route.ts#L24)`) that differs from the exported `UploadDocumentSchema` in `validation.ts` (`.min(1)` vs `.url()`). Worth reconciling.
+
+### U3
+
+`**userId` not found or active-company cookie/DB errors** · Postgres · Working as intended
+
+- **What happens:** Unknown user → 400 "Invalid user" (`[route.ts:67](../../apps/web/src/app/api/uploadDocument/route.ts#L67)`). Thrown DB/cookie errors in `resolveActiveCompanyForUser` → route catch → generic 500.
+- **Left behind:** Nothing (both paths run before the first write). Loud 400/500 + `console.error`.
+- **Notes:** Missing membership does not throw (falls back to default company); only raw DB/cookie failure throws.
+
+### U4
+
+**Insufficient credits in cloud mode** · Postgres (credits) · Needs fix (Low)
+
+- **What happens:** `hasTokens` false → throw with a clear message (`[document-upload.ts:145](../../apps/web/src/server/services/document-upload.ts#L145)`), but the route catch replaces it with `{error:"Failed to start document processing"}` 500 (`[route.ts:102](../../apps/web/src/app/api/uploadDocument/route.ts#L102)`). Check runs before any write.
+- **Left behind:** Nothing. Caller sees a misleading 500; real reason only in server logs.
+- **Notes:** UX-only. Prefer surfacing credits (e.g. 402). Confirm no callers depend on the generic shape.
+
+### U5
+
+`**document` insert fails after client already uploaded bytes** · Object storage + Postgres · Needs discussion
+
+- **What happens:** `createDocumentRecord` throws → route catch → 500. Nothing committed for this doc.
+- **Left behind:** No `document` / `document_versions` / `ocr_jobs`. Upstream storage object may be **orphaned** (client uploaded before this call). 500 is loud; orphan blob is silent.
+- **Notes:** No blob GC for register failures. How common is upload-then-fail-register?
+
+### U6
+
+`**createInitialVersion` fails after `document` insert committed** · Postgres · Needs fix (Mid)
+
+- **What happens:** Version insert + `currentVersionId` update share a transaction and roll back together; the earlier `document` insert does not (`[document-upload.ts:88](../../apps/web/src/server/services/document-upload.ts#L88)`). Route catch → 500.
+- **Left behind:** Orphan `document` with `currentVersionId=NULL`, `ocrProcessed=false`; no version, no `ocr_jobs`, no event. Never processes. 500 to caller; orphan only findable via `currentVersionId IS NULL` and no job.
+- **Notes:** Low probability (same DB, back-to-back) but structural. Wrap `document` + v1 version in one transaction.
+
+### U7
+
+`**dispatcher.dispatch` throws after `document`+version committed** · Inngest · Needs fix (High)
+
+- **What happens:** `triggerDocumentProcessing` wraps + rethrows (`[trigger.ts:103](../../packages/core/src/ocr/trigger.ts#L103)`); `ocr_jobs` insert never reached; route catch → 500.
+- **Left behind:** `document` + `document_versions` committed; **no** `ocr_jobs`, **no** event. Looks pending (`ocrProcessed=false`) forever. Loud at request time; stranded doc silent afterward.
+- **Notes:** Classic dispatch-after-commit gap. No outbox/retry. Client retry of the 500 can also produce [U9](#u9) duplicates.
+
+### U8
+
+**Event dispatched before / without a durable `ocr_jobs` row** · Inngest + Postgres · Needs fix (High)
+
+- **What happens:** Event is sent first; then `db.insert(ocrJobs)` may throw → 500 with event already in flight (`[trigger-job.ts:50](../../apps/web/src/server/services/trigger-job.ts#L50)`). Same ordering also creates a success-path race (worker starts before the insert commits).
+- **Left behind:** `document` + version committed; often **no** `ocr_jobs`. Worker still runs: `savePipelineState` SELECT-then-UPDATE is a silent no-op on a missing row; `loadPipelineState` later throws. Permanent insert failure → retries keep failing. Transient race → Inngest retries usually recover once the row exists (worst case: wasted OCR on attempt 1).
+- **Notes:** Insert `ocr_jobs` **before** dispatch, or use an outbox after commit.
+
+### U9
+
+**Client retries the POST, or concurrent uploads of the same file** · Postgres + Inngest · Needs discussion
+
+- **What happens:** No idempotency key and no unique constraint on `(companyId, url)`. Each request creates a new `document` + v1 version + `ocr_jobs` + event. Writes are pre-Inngest, so memoization does not apply.
+- **Left behind:** Duplicate document trees; file processed 2× (double work/credits). Silent — no constraint violation.
+- **Notes:** Re-upload may be intended product behavior. Sharp case: [U7](#u7) 500 after commit → client retry → duplicates. Concurrent same-file uploads don’t collide on `versionNumber=1` because each gets a distinct `documentId`.
+

--- a/docs/pipeline/pipeline-failure-matrix.md
+++ b/docs/pipeline/pipeline-failure-matrix.md
@@ -41,31 +41,24 @@ Detail cards also record **What happens**, **Left behind** (state + how you’d 
 | --------- | ----------------- | ------------------------- | --------------------------------------------------------- | ------------------- |
 | [D1](#u1) | Embed / Store | Embedding Provider (OpenAI or external sidecar `/embed`)              |                   |  |
 | [D2](#u2) | Embed / Store | Postgres + pgvector (`storeBatch`)                         |                 |  |
-| [D3](#u3) | Embed / Store | Postgres structure/metadat writes                 |         |  |
+| [D3](#u3) | Embed / Store | Postgres structure/metadata writes                 |         |  |
 
 | ID        | Stage             | Dependency                | Failure mode                                              | Status              |
 | --------- | ----------------- | ------------------------- | --------------------------------------------------------- | ------------------- |
-| [E1](#u1) | Finalize |               |                   |  |
-| [E2](#u2) | Finalize |                          |                 |  |
-| [E3](#u3) | Finalize |                  |         |  |
-| [E4](#u4) | Finalize |        |                 |      |
-| [E5](#u5) | Finalize |      |           |     |
+| [E1](#u1) | Finalize | Postgres finalize path (`finalizeStorage`)              |                   |  |
+| [E2](#u2) | Finalize | Status model (`onFailure` + runtime flags)                         |                 |  |
+
 
 | ID        | Stage             | Dependency                | Failure mode                                              | Status              |
 | --------- | ----------------- | ------------------------- | --------------------------------------------------------- | ------------------- |
-| [F1](#u1) | GraphRAG |               |                   |  |
-| [F2](#u2) | GraphRAG |                          |                 |  |
-| [F3](#u3) | GraphRAG |                  |         |  |
-| [F4](#u4) | GraphRAG |        |                 |      |
-| [F5](#u5) | GraphRAG |      |           |     |
+| [F1](#u1) | GraphRAG | External sidecar health (`SIDECAR_URL/health`)              |                   |  |
+| [F2](#u2) | GraphRAG | Entity extraction + Postgres `kg_*` writes                         |                 |  |
+
 
 | ID        | Stage             | Dependency                | Failure mode                                              | Status              |
 | --------- | ----------------- | ------------------------- | --------------------------------------------------------- | ------------------- |
-| [G1](#u1) | Neo4j |               |                   |  |
-| [G2](#u2) | Neo4j |                          |                 |  |
-| [G3](#u3) | Neo4j |                  |         |  |
-| [G4](#u4) | Neo4j |        |                 |      |
-| [G5](#u5) | Neo4j |      |           |     |
+| [G1](#u1) | Neo4j | Neo4j availability/config (`NEO4J_URI`, config, health)              |                   |  |
+| [G2](#u2) | Neo4j | Neo4j write operation (`syncDocumentToNeo4j`)                         |                 |  |
 
 ---
 

--- a/docs/pipeline/pipeline-failure-matrix.md
+++ b/docs/pipeline/pipeline-failure-matrix.md
@@ -45,6 +45,29 @@ Detail cards also record **What happens**, **Left behind** (state + how you’d 
 | [D4](#u4) | Embed / Store |        |                 |      |
 | [D5](#u5) | Embed / Store |      |           |     |
 
+| ID        | Stage             | Dependency                | Failure mode                                              | Status              |
+| --------- | ----------------- | ------------------------- | --------------------------------------------------------- | ------------------- |
+| [E1](#u1) | Finalize |               |                   |  |
+| [E2](#u2) | Finalize |                          |                 |  |
+| [E3](#u3) | Finalize |                  |         |  |
+| [E4](#u4) | Finalize |        |                 |      |
+| [E5](#u5) | Finalize |      |           |     |
+
+| ID        | Stage             | Dependency                | Failure mode                                              | Status              |
+| --------- | ----------------- | ------------------------- | --------------------------------------------------------- | ------------------- |
+| [F1](#u1) | GraphRAG |               |                   |  |
+| [F2](#u2) | GraphRAG |                          |                 |  |
+| [F3](#u3) | GraphRAG |                  |         |  |
+| [F4](#u4) | GraphRAG |        |                 |      |
+| [F5](#u5) | GraphRAG |      |           |     |
+
+| ID        | Stage             | Dependency                | Failure mode                                              | Status              |
+| --------- | ----------------- | ------------------------- | --------------------------------------------------------- | ------------------- |
+| [G1](#u1) | Neo4j |               |                   |  |
+| [G2](#u2) | Neo4j |                          |                 |  |
+| [G3](#u3) | Neo4j |                  |         |  |
+| [G4](#u4) | Neo4j |        |                 |      |
+| [G5](#u5) | Neo4j |      |           |     |
 
 ---
 

--- a/docs/pipeline/pipeline-failure-matrix.md
+++ b/docs/pipeline/pipeline-failure-matrix.md
@@ -39,7 +39,7 @@ Detail cards also record **What happens**, **Left behind** (state + how you’d 
 
 | ID        | Stage             | Dependency                | Failure mode                                              | Status              |
 | --------- | ----------------- | ------------------------- | --------------------------------------------------------- | ------------------- |
-| [D1](#u1) | Embed / Store |               |                   |  |
+| [D1](#u1) | Embed / Store | Embedding Provider (OpenAI or external sidecar /embed)              |                   |  |
 | [D2](#u2) | Embed / Store |                          |                 |  |
 | [D3](#u3) | Embed / Store |                  |         |  |
 | [D4](#u4) | Embed / Store |        |                 |      |


### PR DESCRIPTION
## Summary
- Documents the current document-ingestion pipeline (Stages A–G) end-to-end: entry points, persisted state per stage, and every external dependency touched — grounded in the actual codebase, not assumptions (Task 1.1/2.1, LAU-14 Phase 1).
- Adds a Mermaid state/flow diagram (`pipeline-diagram.mmd`) covering the full pipeline, with fail-hard vs. fail-soft stages visually distinguished and dependencies placed next to the stage that actually uses them.
- Adds failure-matrix rows for Route, OCR/Normalize, and Chunk (A1–A3, B1–B5, C1–C4), plus one cross-cutting correctness bug found while tracing (X1: the `MARKER` OCR provider is dead code, silently mislabeled as `DOCLING`).

## Related
Part of LAU-14: [Core Infrastructure] Phase 1: document the current system (Production-harden the document ingestion pipeline). This PR covers Task 2.1 (pipeline diagram) and Task 2.2 (failure matrix, stages A–C) specifically; Upload/dispatch (Tiffany) and Embed/Store–Neo4j (Sofia) are tracked separately on the same branch.

## Checklist
- [ ] `pnpm check` passes (lint + typecheck)
- [ ] `pnpm test` passes
- [x] Changeset added (if `packages/core/` changed — `pnpm changeset`) — N/A, no code in `packages/core/` was touched, docs only
- [x] New env vars documented in `.env.example` and `apps/web/src/env.ts` — N/A, no new env vars introduced
- [x] UI changes exercised in a browser (not just a green build) — N/A, no UI changes
- [x] Docs updated if behavior changed — this PR *is* the docs update; no runtime behavior was changed

## Testing
No code changes, so no functional test run. Diagram verified by rendering in GitHub's native Mermaid preview and cross-checked against `pipeline-architecture.md` for stage/state/dependency completeness. Failure-matrix rows are grounded in direct reads of the actual source files (`doc-ingestion/index.ts`, `ocr/processor.ts`, `ocr/complexity.ts`, `ocr/adapters/azureAdapter.ts`, `ocr/adapters/ossAdapter.ts`, `ocr/chunker.ts`) , one initial hypothesis (sidecar routing failure behavior) was corrected after reading the real code.

## Notes for reviewers
- This is Phase 1 (documentation only, per LAU-14) — no code changes, no behavior changes. Purely descriptive.