### PR TITLE
Lau 17 harden correctness

### DIFF
--- a/apps/web/__tests__/server/inngest/functions/processDocument.test.ts
+++ b/apps/web/__tests__/server/inngest/functions/processDocument.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Unit tests for the shared onFailure handler in processDocument.ts.
+ * Verifies the failure-status contract: a failed pipeline run must be
+ * honestly marked as failed, not silently treated as success.
+ */
+import { handleProcessDocumentFailure } from "~/server/inngest/functions/processDocumentFailure";
+import { db } from "~/server/db";
+import type { ProcessDocumentEventData } from "@launchstack/core/ocr/types";
+
+jest.mock("~/server/db", () => ({
+  db: { update: jest.fn() },
+}));
+
+const mockDb = db as unknown as { update: jest.Mock };
+
+function makeChain() {
+  const where = jest.fn().mockResolvedValue(undefined);
+  const set = jest.fn(() => ({ where }));
+  return { set, where };
+}
+
+function makeEvent(data: Partial<ProcessDocumentEventData>) {
+  return { data: { event: { data: data as ProcessDocumentEventData } } } as any;
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("handleProcessDocumentFailure", () => {
+  it("marks document.ocrProcessed as false (not true) on failure", async () => {
+    const chain = makeChain();
+    mockDb.update.mockReturnValueOnce({ set: chain.set });
+
+    await handleProcessDocumentFailure({
+      error: new Error("OCR provider timed out"),
+      event: makeEvent({ documentId: 42, jobId: "job-1" }),
+    });
+
+    expect(chain.set).toHaveBeenCalledWith(
+      expect.objectContaining({ ocrProcessed: false }),
+    );
+  });
+
+  it("stores the real error message in document.ocrMetadata", async () => {
+    const chain = makeChain();
+    mockDb.update.mockReturnValueOnce({ set: chain.set });
+
+    await handleProcessDocumentFailure({
+      error: new Error("OCR provider timed out"),
+      event: makeEvent({ documentId: 42, jobId: "job-1" }),
+    });
+
+    expect(chain.set).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ocrMetadata: expect.objectContaining({
+          error: "processing_failed",
+          errorMessage: "OCR provider timed out",
+        }),
+      }),
+    );
+  });
+
+  it("sets ocr_jobs.status to 'failed' instead of leaving it queued", async () => {
+    const docChain = makeChain();
+    const jobChain = makeChain();
+    mockDb.update
+      .mockReturnValueOnce({ set: docChain.set })
+      .mockReturnValueOnce({ set: jobChain.set });
+
+    await handleProcessDocumentFailure({
+      error: new Error("boom"),
+      event: makeEvent({ documentId: 42, jobId: "job-1" }),
+    });
+
+    expect(jobChain.set).toHaveBeenCalledWith(
+      expect.objectContaining({ status: "failed" }),
+    );
+  });
+
+  it("does not touch ocr_jobs if jobId is missing", async () => {
+    const chain = makeChain();
+    mockDb.update.mockReturnValueOnce({ set: chain.set });
+
+    await handleProcessDocumentFailure({
+      error: new Error("boom"),
+      event: makeEvent({ documentId: 42 }),
+    });
+
+    expect(mockDb.update).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not throw if the database update itself fails", async () => {
+    mockDb.update.mockImplementationOnce(() => {
+      throw new Error("connection lost");
+    });
+
+    await expect(
+      handleProcessDocumentFailure({
+        error: new Error("original failure"),
+        event: makeEvent({ documentId: 42, jobId: "job-1" }),
+      }),
+    ).resolves.not.toThrow();
+  });
+});

--- a/apps/web/src/server/inngest/functions/processDocument.ts
+++ b/apps/web/src/server/inngest/functions/processDocument.ts
@@ -327,30 +327,45 @@ export const uploadDocument = inngest.createFunction(
     timeouts: { finish: "120m" },
     onFailure: async ({ error, event }) => {
       console.error(`[ProcessDocument] Pipeline failed for job ${JSON.stringify(event.data)}:`, error);
-
       const data = event.data?.event?.data as ProcessDocumentEventData | undefined;
+      const errorMessage = error instanceof Error ? error.message : String(error);
+
       if (data?.documentId) {
         try {
           await db
             .update(document)
             .set({
-              ocrProcessed: true,
+              ocrProcessed: false,
               ocrMetadata: {
                 error: "processing_failed",
-                errorMessage: error instanceof Error ? error.message : String(error),
+                errorMessage,
                 failedAt: new Date().toISOString(),
               },
             })
             .where(eq(document.id, data.documentId));
-          console.log(
-            `[ProcessDocument] Marked document ${data.documentId} as failed`,
-          );
+          console.log(`[ProcessDocument] Marked document ${data.documentId} as failed`);
         } catch (dbError) {
           console.error("[ProcessDocument] Could not mark document as failed:", dbError);
         }
       }
+
+      if (data?.jobId) {
+          try {
+            await db
+              .update(ocrJobs)
+              .set({
+                status: "failed",
+                errorMessage,
+                completedAt: new Date(),
+              })
+              .where(eq(ocrJobs.id, data.jobId));
+            console.log(`[ProcessDocument] Marked ocr_jobs ${data.jobId} as failed`);
+          } catch (dbError) {
+            console.error("[ProcessDocument] Could not mark job as failed:", dbError);
+          }
+        }
+      },
     },
-  },
   { event: "document/process.requested" },
   async ({ event, step }) => {
     const eventData = event.data;

--- a/apps/web/src/server/inngest/functions/processDocument.ts
+++ b/apps/web/src/server/inngest/functions/processDocument.ts
@@ -316,7 +316,7 @@ function sniffTextContent(buffer: Buffer): boolean {
 // ---------------------------------------------------------------------------
 // Inngest Function
 // ---------------------------------------------------------------------------
-
+import { handleProcessDocumentFailure } from "./processDocumentFailure";
 export const uploadDocument = inngest.createFunction(
   {
     id: "process-document",
@@ -325,46 +325,7 @@ export const uploadDocument = inngest.createFunction(
     concurrency: [{ limit: 3 }],
     throttle: { limit: 30, period: "1m" },
     timeouts: { finish: "120m" },
-    onFailure: async ({ error, event }) => {
-      console.error(`[ProcessDocument] Pipeline failed for job ${JSON.stringify(event.data)}:`, error);
-      const data = event.data?.event?.data as ProcessDocumentEventData | undefined;
-      const errorMessage = error instanceof Error ? error.message : String(error);
-
-      if (data?.documentId) {
-        try {
-          await db
-            .update(document)
-            .set({
-              ocrProcessed: false,
-              ocrMetadata: {
-                error: "processing_failed",
-                errorMessage,
-                failedAt: new Date().toISOString(),
-              },
-            })
-            .where(eq(document.id, data.documentId));
-          console.log(`[ProcessDocument] Marked document ${data.documentId} as failed`);
-        } catch (dbError) {
-          console.error("[ProcessDocument] Could not mark document as failed:", dbError);
-        }
-      }
-
-      if (data?.jobId) {
-          try {
-            await db
-              .update(ocrJobs)
-              .set({
-                status: "failed",
-                errorMessage,
-                completedAt: new Date(),
-              })
-              .where(eq(ocrJobs.id, data.jobId));
-            console.log(`[ProcessDocument] Marked ocr_jobs ${data.jobId} as failed`);
-          } catch (dbError) {
-            console.error("[ProcessDocument] Could not mark job as failed:", dbError);
-          }
-        }
-      },
+    onFailure: handleProcessDocumentFailure,
     },
   { event: "document/process.requested" },
   async ({ event, step }) => {

--- a/apps/web/src/server/inngest/functions/processDocumentFailure.ts
+++ b/apps/web/src/server/inngest/functions/processDocumentFailure.ts
@@ -1,0 +1,51 @@
+import { eq } from "drizzle-orm";
+import { db } from "~/server/db";
+import { document, ocrJobs } from "@launchstack/core/db/schema";
+import type { ProcessDocumentEventData } from "@launchstack/core/ocr/types";
+
+export async function handleProcessDocumentFailure({
+  error,
+  event,
+}: {
+  error: unknown;
+  event: { data?: { event?: { data?: ProcessDocumentEventData } } };
+}): Promise<void> {
+  console.error(`[ProcessDocument] Pipeline failed for job ${JSON.stringify(event.data)}:`, error);
+  const data = event.data?.event?.data as ProcessDocumentEventData | undefined;
+  const errorMessage = error instanceof Error ? error.message : String(error);
+
+  if (data?.documentId) {
+    try {
+      await db
+        .update(document)
+        .set({
+          ocrProcessed: false,
+          ocrMetadata: {
+            error: "processing_failed",
+            errorMessage,
+            failedAt: new Date().toISOString(),
+          },
+        })
+        .where(eq(document.id, data.documentId));
+      console.log(`[ProcessDocument] Marked document ${data.documentId} as failed`);
+    } catch (dbError) {
+      console.error("[ProcessDocument] Could not mark document as failed:", dbError);
+    }
+  }
+
+  if (data?.jobId) {
+    try {
+      await db
+        .update(ocrJobs)
+        .set({
+          status: "failed",
+          errorMessage,
+          completedAt: new Date(),
+        })
+        .where(eq(ocrJobs.id, data.jobId));
+      console.log(`[ProcessDocument] Marked ocr_jobs ${data.jobId} as failed`);
+    } catch (dbError) {
+      console.error("[ProcessDocument] Could not mark job as failed:", dbError);
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Fixes the shared Inngest `onFailure` handler so a permanently failed document/job is honestly distinguishable from one still in progress. `document.ocrProcessed` now correctly sets to `false` on failure (was `true`, identical to success), and `ocr_jobs.status` now correctly sets to `"failed"` (a value already supported by the schema but never written on the live path — jobs previously stayed stuck at `"queued"` forever).
- Extracts the failure-handling logic out of `processDocument.ts` into its own file, `processDocumentFailure.ts`, so it can be unit tested in isolation without pulling in the full pipeline's heavy dependency chain (RAG retrievers, Neo4j client, `engine.ts`).
- Adds a unit test suite covering the failure-status contract: confirms the correct fields get set, confirms missing IDs are handled safely, and confirms a broken database call during failure-handling itself doesn't crash the handler.

## Related
Part of LAU-17, [Core Infrastructure] Phase 2: harden correctness and recovery, item 2 ("Failure-status marking"), subtasks 1 and 2 of 3 ("Fix the shared `onFailure` handler" and "Test the failure contract"). 

## Checklist
- [x] `pnpm check` passes (lint + typecheck) — scoped: `pnpm typecheck` in `apps/web` passes cleanly; `eslint` on the changed files passes aside from 2 pre-existing issues elsewhere in `processDocument.ts` unrelated to this change (confirmed via `git show` — both flagged lines predate this diff). Full monorepo-wide `pnpm check` hits a local memory limit (`JavaScript heap out of memory`) on this machine; not run in full locally.
- [x] `pnpm test` passes — scoped: `npx jest __tests__/server/inngest/functions/processDocument.test.ts` — 5/5 passing.
- [x] Changeset added (if `packages/core/` changed — `pnpm changeset`) — N/A, only `apps/web` was touched
- [x] New env vars documented in `.env.example` and `apps/web/src/env.ts` — N/A, no new env vars
- [x] UI changes exercised in a browser (not just a green build) — N/A, no UI changes
- [ ] Docs updated if behavior changed — `pipeline-failure-matrix.md` rows B1/B4/B5/C1 still reference the old "stuck queued forever" behavior and need a follow-up update once this merges; deliberately not bundled into this PR

## Testing
Ran `pnpm typecheck` (clean) and `npx jest __tests__/server/inngest/functions/processDocument.test.ts` (5/5 passing) from `apps/web`. Test scenarios covered:
1. `document.ocrProcessed` is set to `false` (not `true`) on failure.
2. The real error message is stored in `document.ocrMetadata`.
3. `ocr_jobs.status` is set to `"failed"`.
4. The `ocr_jobs` update is correctly skipped (not attempted) when `jobId` is missing from the event data.
5. A database error thrown *while attempting to record the failure* does not propagate out of the handler, it's caught internally and the function still resolves normally.

Full monorepo-wide `eslint . && pnpm -r typecheck` was attempted but crashed locally with an out-of-memory error; CI should be relied on for full-repo verification.

## Notes for reviewers
- Deliberately did **not** flip `markFailureInDb: false` → `true` on the `runDocIngestionTool` runtime options in `processDocument.ts`. That flag triggers `markJobFailed` on *every* failed attempt, including ones Inngest is about to retry — flipping it would prematurely mark a job `"failed"` mid-retry. The Inngest-level `onFailure` handler (what this PR fixes) only fires once, after all 5 retries are genuinely exhausted, which is the correct single place for this.
- The extraction into `processDocumentFailure.ts` is a structural change, not just a testing convenience,happy to discuss if the team would prefer a different file organization, but this keeps the failure-handling logic minimal and independently reasoned-about.
