### PR TITLE
spike: test Vercel legacy OpenAI env hypothesis

### DIFF
--- a/apps/web/__tests__/server/chat-models-env.test.ts
+++ b/apps/web/__tests__/server/chat-models-env.test.ts
@@ -49,21 +49,20 @@ describe("one-release legacy translation", () => {
       { AI_BASE_URL: "  http://localhost:11434/v1  " },
       { baseUrl: "http://localhost:11434/v1", apiKey: undefined },
     ],
+    [
+      { OPENAI_API_KEY: "sk-legacy" },
+      { baseUrl: "https://api.openai.com/v1", apiKey: "sk-legacy" },
+    ],
   ])("translates %p to a single endpoint", (environment, expected) => {
     const translated = translateLegacyEndpoint(environment);
     expect(translated?.endpoint).toEqual(expected);
     expect(translated?.deprecation).toMatch(/deprecated/);
   });
 
-  it.each([
-    [{ OPENROUTER_API_KEY: "sk-or-v1-x" }],
-    [{ OPENAI_API_KEY: "sk-x" }],
-    [{ OPENROUTER_API_KEY: "sk-or-v1-x", OPENAI_API_KEY: "sk-x" }],
-  ])("refuses to infer an endpoint from the bare credential %p", (environment) => {
-    // There are no built-in vendor URLs. A key says who you are, not where to
-    // send the request — inferring one would pick a vendor on the operator's
-    // behalf and ship their prompts there.
-    expect(translateLegacyEndpoint(environment)).toBeUndefined();
+  it("does not infer an endpoint from a bare OpenRouter credential", () => {
+    expect(
+      translateLegacyEndpoint({ OPENROUTER_API_KEY: "sk-or-v1-x" }),
+    ).toBeUndefined();
   });
 
   it("no longer treats OLLAMA_BASE_URL as a chat endpoint", () => {
@@ -79,7 +78,7 @@ describe("one-release legacy translation", () => {
     ).toThrow(/CHAT_BASE_URL is not set/);
   });
 
-  it("ignores OPENAI_API_KEY entirely — it is the embeddings credential", () => {
+  it("lets an explicit AI endpoint override OPENAI_API_KEY", () => {
     // "Some other endpoint for chat, OpenAI-compatible for embeddings" is a
     // normal pairing, so its presence must not disturb chat resolution.
     expect(
@@ -91,9 +90,11 @@ describe("one-release legacy translation", () => {
     ).toEqual({ baseUrl: "https://api.siliconflow.cn/v1", apiKey: "sf" });
   });
 
-  it("names the bare credential when it explains the failure", () => {
-    expect(() => resolveChatEndpoint({ OPENAI_API_KEY: "sk-x" })).toThrow(
-      /OPENAI_API_KEY is set, but a credential no longer selects an endpoint/,
+  it("names an unsupported bare credential when it explains the failure", () => {
+    expect(() =>
+      resolveChatEndpoint({ OPENROUTER_API_KEY: "sk-or-v1-x" }),
+    ).toThrow(
+      /OPENROUTER_API_KEY is set, but a credential no longer selects an endpoint/,
     );
   });
 });
@@ -104,13 +105,13 @@ describe("credential presence checks", () => {
     expect(hasConfiguredAiCredential({ CHAT_BASE_URL: "  " })).toBe(false);
     expect(hasConfiguredAiCredential({ CHAT_BASE_URL: "https://x/v1" })).toBe(true);
     expect(hasConfiguredAiCredential({ AI_BASE_URL: "https://x/v1" })).toBe(true);
+    expect(hasConfiguredAiCredential({ OPENAI_API_KEY: "sk-x" })).toBe(true);
   });
 
   it("reports only what resolveChatEndpoint would actually accept", () => {
     // Reporting true here would tell a health check chat is ready moments
     // before resolveChatEndpoint refuses to boot on the same environment.
     expect(hasConfiguredAiCredential({ OPENROUTER_API_KEY: "k" })).toBe(false);
-    expect(hasConfiguredAiCredential({ OPENAI_API_KEY: "sk-x" })).toBe(false);
     expect(hasConfiguredAiCredential({ OLLAMA_BASE_URL: "http://x:11434" })).toBe(false);
   });
 });

--- a/apps/web/src/server/ai-credentials.ts
+++ b/apps/web/src/server/ai-credentials.ts
@@ -11,15 +11,13 @@ export interface AiCredentialEnvironment {
   CHAT_BASE_URL?: string;
   /** @deprecated Pre-PR name for CHAT_BASE_URL. */
   AI_BASE_URL?: string;
+  /** Pre-PR OpenAI credential accepted as a one-release deployment fallback. */
+  OPENAI_API_KEY?: string;
   /**
-   * Declared because real environments carry them, and deliberately *not*
-   * treated as endpoint sources. A bare credential names no URL, and
-   * OLLAMA_BASE_URL names a provider whose OpenAI-compatible endpoint is
-   * reached through CHAT_BASE_URL like any other. See
-   * {@link getDeprecatedChatEndpointSources}.
+   * Declared because real environments carry these, but not treated as chat
+   * endpoint sources.
    */
   OPENROUTER_API_KEY?: string;
-  OPENAI_API_KEY?: string;
   OLLAMA_BASE_URL?: string;
 }
 
@@ -30,17 +28,13 @@ function configured(value: string | undefined): boolean {
 /**
  * Deprecated variables that still resolve to an endpoint this release.
  * Reported so setup surfaces can nudge operators onto CHAT_BASE_URL.
- *
- * Only variables carrying an explicit URL qualify. A bare credential
- * (OPENROUTER_API_KEY, OPENAI_API_KEY) no longer names an endpoint, so
- * reporting it here would tell a health check that chat is configured when
- * resolveChatEndpoint is about to refuse to boot.
  */
 export function getDeprecatedChatEndpointSources(
   environment: AiCredentialEnvironment,
 ): string[] {
   return [
     configured(environment.AI_BASE_URL) ? "AI_BASE_URL" : undefined,
+    configured(environment.OPENAI_API_KEY) ? "OPENAI_API_KEY" : undefined,
   ].filter((source): source is string => Boolean(source));
 }
 

--- a/apps/web/src/server/chat-endpoint.ts
+++ b/apps/web/src/server/chat-endpoint.ts
@@ -31,13 +31,10 @@ export interface AppChatModelEnvironment {
   AI_BASE_URL?: string;
   /** @deprecated Pre-PR name for CHAT_API_KEY. */
   AI_API_KEY?: string;
-  /**
-   * Read only to explain a failure. A bare credential no longer selects an
-   * endpoint: there are no built-in vendor URLs, so a key on its own says
-   * nothing about where to send the request. See {@link BARE_CREDENTIALS}.
-   */
-  OPENROUTER_API_KEY?: string;
+  /** Pre-PR OpenAI credential accepted as a one-release deployment fallback. */
   OPENAI_API_KEY?: string;
+  /** Read only to explain why a bare OpenRouter credential is insufficient. */
+  OPENROUTER_API_KEY?: string;
   /**
    * Declared because the environment still carries it — it configures the
    * Ollama *embeddings* provider — but deliberately ignored for chat. Ollama
@@ -52,6 +49,7 @@ export interface AppChatModelEnvironment {
 }
 
 export const DEFAULT_CHAT_CONFIG_PATH = "config/chat-models.yaml";
+const LEGACY_OPENAI_BASE_URL = "https://api.openai.com/v1";
 
 export function trimmed(value: string | undefined): string | undefined {
   const text = value?.trim();
@@ -59,32 +57,34 @@ export function trimmed(value: string | undefined): string | undefined {
 }
 
 /**
- * Credentials that used to imply a vendor's URL. They no longer do — the
- * mapping key-to-endpoint is exactly the vendor lock-in this module exists to
- * avoid, and a built-in default silently decides on the operator's behalf
- * where their prompts and their key are sent. Listed here only so
- * {@link resolveChatEndpoint} can say why a key alone was not enough.
+ * A bare OpenRouter credential cannot identify which compatible endpoint the
+ * operator intended. Keep it only so configuration errors name the omission.
  */
-const BARE_CREDENTIALS = ["OPENROUTER_API_KEY", "OPENAI_API_KEY"] as const;
+const BARE_CREDENTIALS = ["OPENROUTER_API_KEY"] as const;
 
 /**
- * Map the one surviving pre-PR alias onto the endpoint.
+ * Map supported pre-PR configuration onto the canonical chat endpoint.
  *
- * `AI_BASE_URL`/`AI_API_KEY` are a straight rename of `CHAT_BASE_URL`/
- * `CHAT_API_KEY`: the operator writes the URL either way, so translating them
- * infers nothing.
- *
- * No variable names a *provider*. Ollama, OpenRouter and OpenAI all serve the
- * OpenAI chat-completions protocol, so each is reached through CHAT_BASE_URL
- * like any other endpoint. A per-vendor variable bought only a vendor to
- * maintain — and, for the two that mapped a bare key to a URL, a destination
- * chosen on the operator's behalf.
+ * `AI_BASE_URL`/`AI_API_KEY` are a straight rename. For one release, an
+ * otherwise-unconfigured `OPENAI_API_KEY` retains the pre-PR OpenAI endpoint
+ * behavior so deployed environments can migrate without an outage.
  */
 export function translateLegacyEndpoint(
   server: AppChatModelEnvironment,
 ): { endpoint: ChatEndpointConfig; deprecation?: string } | undefined {
   const baseUrl = trimmed(server.AI_BASE_URL);
-  if (!baseUrl) return undefined;
+  if (!baseUrl) {
+    const apiKey = trimmed(server.OPENAI_API_KEY);
+    if (!apiKey) return undefined;
+
+    return {
+      endpoint: { baseUrl: LEGACY_OPENAI_BASE_URL, apiKey },
+      deprecation:
+        "[chat] OPENAI_API_KEY without CHAT_BASE_URL is deprecated and will be " +
+        `removed next release. Set CHAT_BASE_URL=${LEGACY_OPENAI_BASE_URL} and ` +
+        "CHAT_API_KEY instead.",
+    };
+  }
 
   const endpoint: ChatEndpointConfig = {
     baseUrl,


### PR DESCRIPTION
## Experiment

Assume the failing Vercel Preview environments still provide `OPENAI_API_KEY` but not the new `CHAT_BASE_URL` / `CHAT_API_KEY` pair introduced by the chat configuration cutover.

This spike restores the pre-PR OpenAI behavior for one release only when no explicit chat or AI endpoint is configured:

- `CHAT_BASE_URL` remains authoritative.
- `AI_BASE_URL` remains the explicit legacy alias.
- A lone `OPENAI_API_KEY` falls back to `https://api.openai.com/v1` and emits a migration warning.
- A lone OpenRouter key still fails because it does not safely identify an endpoint.

Do not merge this draft based only on local results. Its purpose is to trigger both Vercel Preview projects and test the environment-contract hypothesis without touching PR #308.

## Local evidence

- Endpoint suite: 19 tests passed.
- Web typecheck: passed.
- Production build with only legacy `OPENAI_API_KEY`: passed.
- Production build with canonical `CHAT_BASE_URL` / `CHAT_API_KEY`: passed.

## Interpretation

- Both Vercel previews green: strong evidence the missing canonical chat environment variables caused the prior failures.
- Either preview still red: this hypothesis is insufficient; obtain the first failing Vercel build line before changing production behavior.