### PR TITLE
Founder review scenario test framework

### DIFF
--- a/apps/web/__tests__/founderWeeklyReview/scenario-collection.integration.test.ts
+++ b/apps/web/__tests__/founderWeeklyReview/scenario-collection.integration.test.ts
@@ -1,0 +1,262 @@
+/**
+ * Runs every scenario fixture and enforces its `expect` block.
+ *
+ * This is the half the fixtures were missing. A scenario that only describes
+ * inputs cannot fail: the cross-company isolation case would report success
+ * while another company's evidence sat in the snapshot. Every field a fixture
+ * declares under `expect` is asserted below, and an `expect` block is
+ * mandatory in the contract, so adding a fixture without expectations is a
+ * parse error rather than silent non-coverage.
+ *
+ * Provider-free. Collection needs no model, and the one review assertion here
+ * (`review.sectionStates`) uses the empty-evidence path, which builds its
+ * review without calling one — the injected generator throws if it is ever
+ * reached.
+ */
+
+import { readdir } from "node:fs/promises";
+import { join } from "node:path";
+
+import {
+    FounderWeeklyReviewEvidenceService,
+    FounderWeeklyReviewEvidenceSnapshotSchema,
+    generateFounderWeeklyReview,
+    type FounderWeeklyReviewEvidenceSnapshot,
+} from "@launchstack/features/founder-weekly-review";
+import { FounderWeeklyReviewDocumentVersionStore } from "~/server/founder-weekly-review/document-version-chunks";
+import { StrictCurrentWorkspaceDocumentStore } from "~/server/founder-weekly-review/workspace-document-store";
+
+import { loadScenario } from "../../scripts/founder-weekly-review-scenario-loader";
+import {
+    seedScenario,
+    type SeededScenario,
+} from "../../scripts/founder-weekly-review-scenario-seeder";
+import type { FounderWeeklyReviewScenario } from "../../test-fixtures/founder-weekly-review/scenarios/contracts";
+import { createFounderWeeklyReviewTestDatabase } from "./testDb";
+
+const describeIfDatabase =
+    process.env.LAUNCHSTACK_TEST_DATABASE_URL ?? process.env.DATABASE_URL
+        ? describe
+        : describe.skip;
+
+const SCENARIO_DIR = join(__dirname, "..", "..", "test-fixtures", "founder-weekly-review", "scenarios");
+const CAPTURED_AT = new Date("2026-07-27T00:00:00.000Z");
+const CUSTOMER_FEEDBACK_CATEGORY = "Customer Feedback";
+
+/** Kept in step with the directories on disk by the first test below. */
+const SCENARIOS = [
+    "01-empty-evidence",
+    "02-founder-context-only",
+    "03-relevant-workspace-document",
+    "04-first-ever-version-no-invented-diff",
+    "05-multiple-versions-in-period",
+    "06-customer-feedback",
+    "09-cross-company-isolation",
+] as const;
+
+/**
+ * Workspace retrieval is embedding-based. Scenarios that assert on
+ * `workspace_document` get a deterministic stub embedder so the assertion is
+ * about the collector's wiring rather than about model similarity scores.
+ */
+const deterministicVector = () => Array.from({ length: 1536 }, (_, index) => (index === 0 ? 1 : 0));
+
+function needsWorkspaceRetrieval(scenario: FounderWeeklyReviewScenario): boolean {
+    const counts = scenario.expect.evidence?.sourceTypeCounts;
+    return (
+        scenario.expect.sourceSemantics?.currentWorkspaceOnly === true ||
+        (counts?.workspace_document !== undefined && counts.workspace_document.exact !== 0)
+    );
+}
+
+interface CollectedScenario {
+    scenario: FounderWeeklyReviewScenario;
+    snapshot: FounderWeeklyReviewEvidenceSnapshot;
+    seeded: SeededScenario;
+}
+
+async function collect(name: string): Promise<CollectedScenario> {
+    const scenario = await loadScenario(join(SCENARIO_DIR, name, "scenario.json"));
+    const testDb = await createFounderWeeklyReviewTestDatabase();
+    try {
+        const withRetrieval = needsWorkspaceRetrieval(scenario);
+        const seeded = await seedScenario(testDb.db, scenario, {
+            deterministicWorkspaceEmbeddings: withRetrieval,
+        });
+        const collector = new FounderWeeklyReviewEvidenceService(
+            testDb.db,
+            () => CAPTURED_AT,
+            { kind: "computed", store: new FounderWeeklyReviewDocumentVersionStore(testDb.db) },
+            withRetrieval
+                ? new StrictCurrentWorkspaceDocumentStore(testDb.db, {
+                      embedQuery: async () => deterministicVector(),
+                  })
+                : undefined
+        );
+        const snapshot = await collector.collectFounderWeeklyReviewEvidence({
+            companyId: seeded.underReviewCompanyId,
+            reportingPeriod: scenario.reportingPeriod,
+            workspaceTimezone: scenario.workspaceTimezone,
+            founderContext: scenario.founderContext,
+            actor: scenario.founderContext ? { externalUserId: "scenario-test" } : undefined,
+            requestKey: `scenario-${scenario.name}`,
+            capturedAt: CAPTURED_AT,
+        });
+        return {
+            scenario,
+            snapshot: FounderWeeklyReviewEvidenceSnapshotSchema.parse(snapshot),
+            seeded,
+        };
+    } finally {
+        await testDb.close();
+    }
+}
+
+function assertEvidenceExpectations(
+    scenario: FounderWeeklyReviewScenario,
+    snapshot: FounderWeeklyReviewEvidenceSnapshot
+): void {
+    const evidence = scenario.expect.evidence;
+    if (!evidence) return;
+
+    for (const [sourceType, bounds] of Object.entries(evidence.sourceTypeCounts ?? {})) {
+        const count = snapshot.items.filter((item) => item.sourceType === sourceType).length;
+        if (bounds?.exact !== undefined) {
+            expect({ sourceType, count }).toEqual({ sourceType, count: bounds.exact });
+        }
+        if (bounds?.min !== undefined) expect(count).toBeGreaterThanOrEqual(bounds.min);
+        if (bounds?.max !== undefined) expect(count).toBeLessThanOrEqual(bounds.max);
+    }
+
+    const reported = snapshot.sourceWarnings.map((warning) => warning.code);
+    for (const code of evidence.warningCodes ?? []) expect(reported).toContain(code);
+    for (const code of evidence.forbiddenWarningCodes ?? []) expect(reported).not.toContain(code);
+}
+
+function assertSourceSemantics(
+    scenario: FounderWeeklyReviewScenario,
+    snapshot: FounderWeeklyReviewEvidenceSnapshot,
+    seeded: SeededScenario
+): void {
+    const semantics = scenario.expect.sourceSemantics;
+    if (!semantics) return;
+
+    if (semantics.temporalEvidenceRequired) {
+        // A change without a timestamp cannot be placed in a reporting period,
+        // so it cannot honestly be cited as something that happened this week.
+        for (const item of snapshot.items.filter((entry) => entry.sourceType === "document_change")) {
+            expect({ sourceId: item.sourceId, hasTimestamp: item.sourceTimestamp !== undefined }).toEqual({
+                sourceId: item.sourceId,
+                hasTimestamp: true,
+            });
+        }
+    }
+
+    if (semantics.currentWorkspaceOnly) {
+        // Retrieved current-state documents must not be re-reported as changes.
+        const workspaceDocumentIds = new Set(
+            snapshot.items
+                .filter((item) => item.sourceType === "workspace_document")
+                .map((item) => String(item.metadata.documentId))
+        );
+        for (const item of snapshot.items.filter((entry) => entry.sourceType === "document_change")) {
+            expect(workspaceDocumentIds).not.toContain(String(item.metadata.documentId));
+        }
+    }
+
+    if (semantics.customerFeedbackOnly) {
+        // Only customer_feedback items may be sourced from a Customer Feedback
+        // document. Founder context in particular is direction, not testimony.
+        const feedbackTitles = new Set(
+            scenario.companies.flatMap((company) =>
+                company.documents
+                    .filter((doc) => doc.category === CUSTOMER_FEEDBACK_CATEGORY)
+                    .map((doc) => doc.title)
+            )
+        );
+        for (const item of snapshot.items) {
+            if (item.sourceType === "customer_feedback") continue;
+            expect({ sourceId: item.sourceId, fromFeedbackDoc: feedbackTitles.has(item.title) }).toEqual({
+                sourceId: item.sourceId,
+                fromFeedbackDoc: false,
+            });
+        }
+    }
+
+    if (semantics.noCrossCompanyLeakage) {
+        const underReviewName = scenario.companies.find((entry) => entry.underReview)!.name;
+        const foreignDocumentIds = new Set(
+            [...seeded.documentIdsByCompanyName.entries()]
+                .filter(([name]) => name !== underReviewName)
+                .flatMap(([, ids]) => ids.map((id) => id.toString()))
+        );
+        const foreignTitles = new Set(
+            [...seeded.documentTitlesByCompanyName.entries()]
+                .filter(([name]) => name !== underReviewName)
+                .flatMap(([, titles]) => titles)
+        );
+        expect(foreignDocumentIds.size).toBeGreaterThan(0);
+
+        for (const item of snapshot.items) {
+            const documentId = item.metadata.documentId;
+            expect({
+                sourceId: item.sourceId,
+                foreignDocument:
+                    documentId !== undefined && foreignDocumentIds.has(String(documentId)),
+            }).toEqual({ sourceId: item.sourceId, foreignDocument: false });
+            expect({ sourceId: item.sourceId, foreignTitle: foreignTitles.has(item.title) }).toEqual({
+                sourceId: item.sourceId,
+                foreignTitle: false,
+            });
+            // The id also appears inside the composed sourceId, so check the
+            // rendered string too rather than trusting metadata alone.
+            for (const foreignId of foreignDocumentIds) {
+                expect(item.sourceId).not.toContain(`:doc:${foreignId}:`);
+            }
+        }
+    }
+}
+
+async function assertReviewExpectations(
+    scenario: FounderWeeklyReviewScenario,
+    snapshot: FounderWeeklyReviewEvidenceSnapshot
+): Promise<void> {
+    const sectionStates = scenario.expect.review?.sectionStates;
+    if (!sectionStates) return;
+
+    const generated = await generateFounderWeeklyReview({
+        evidenceSnapshot: snapshot,
+        generate: () => {
+            throw new Error(
+                "review.sectionStates is only assertable on the deterministic no-model path; " +
+                    "this scenario produced evidence and would require a real generation call."
+            );
+        },
+    });
+
+    for (const [section, state] of Object.entries(sectionStates)) {
+        const actual =
+            generated.reviewPayload.sections[section as keyof typeof generated.reviewPayload.sections];
+        expect({ section, state: actual?.state }).toEqual({ section, state });
+    }
+}
+
+describeIfDatabase("founder weekly review scenarios (provider-free collection)", () => {
+    jest.setTimeout(120_000);
+
+    it("covers every scenario directory on disk", async () => {
+        // Guards the it.each list below: a fixture added without being
+        // registered here would otherwise never run.
+        const entries = await readdir(SCENARIO_DIR, { withFileTypes: true });
+        const onDisk = entries.filter((entry) => entry.isDirectory()).map((entry) => entry.name).sort();
+        expect(onDisk).toEqual([...SCENARIOS].sort());
+    });
+
+    it.each(SCENARIOS)("%s satisfies its declared expectations", async (name) => {
+        const { scenario, snapshot, seeded } = await collect(name);
+        expect(snapshot.schemaVersion).toBe("founder-weekly-review-evidence/v1");
+        assertEvidenceExpectations(scenario, snapshot);
+        assertSourceSemantics(scenario, snapshot, seeded);
+        await assertReviewExpectations(scenario, snapshot);
+    });
+});

--- a/apps/web/__tests__/founderWeeklyReview/scenario-contract.test.ts
+++ b/apps/web/__tests__/founderWeeklyReview/scenario-contract.test.ts
@@ -1,0 +1,158 @@
+/**
+ * The scenario contract's own rules — the ones that stop an unfalsifiable or
+ * unseedable fixture from reaching the integration suite.
+ */
+
+import {
+    FOUNDER_WEEKLY_REVIEW_SCENARIO_SCHEMA_VERSION,
+    FounderWeeklyReviewScenarioSchema,
+} from "../../test-fixtures/founder-weekly-review/scenarios/contracts";
+
+const base = {
+    name: "example",
+    reportingPeriod: { start: "2026-07-20", end: "2026-07-26" },
+    workspaceTimezone: "America/New_York",
+    companies: [{ name: "Northstar Analytics", underReview: true, documents: [] }],
+    expect: { evidence: { sourceTypeCounts: { founder_context: { exact: 0 } } } },
+};
+
+describe("founder weekly review scenario contract", () => {
+    it("defaults the schema version and normalizes optional collections", () => {
+        const parsed = FounderWeeklyReviewScenarioSchema.parse(base);
+        expect(parsed.schemaVersion).toBe(FOUNDER_WEEKLY_REVIEW_SCENARIO_SCHEMA_VERSION);
+        expect(parsed.companies[0]!.documents).toEqual([]);
+    });
+
+    it("rejects a scenario with no expectations", () => {
+        // The defect this contract exists to prevent: a fixture that cannot fail.
+        const withoutExpect = { ...base };
+        delete (withoutExpect as Partial<typeof base>).expect;
+        expect(() => FounderWeeklyReviewScenarioSchema.parse(withoutExpect)).toThrow();
+        expect(() => FounderWeeklyReviewScenarioSchema.parse({ ...base, expect: {} })).toThrow(
+            /expect must assert something/
+        );
+    });
+
+    it("rejects a count expectation that constrains nothing", () => {
+        expect(() =>
+            FounderWeeklyReviewScenarioSchema.parse({
+                ...base,
+                expect: { evidence: { sourceTypeCounts: { founder_context: {} } } },
+            })
+        ).toThrow(/must constrain something/);
+    });
+
+    it("rejects contradictory count bounds", () => {
+        expect(() =>
+            FounderWeeklyReviewScenarioSchema.parse({
+                ...base,
+                expect: { evidence: { sourceTypeCounts: { document_change: { min: 3, max: 1 } } } },
+            })
+        ).toThrow(/min must not exceed max/);
+        expect(() =>
+            FounderWeeklyReviewScenarioSchema.parse({
+                ...base,
+                expect: {
+                    evidence: { sourceTypeCounts: { document_change: { min: 2, exact: 1 } } },
+                },
+            })
+        ).toThrow(/exact must satisfy min\/max/);
+    });
+
+    it("requires exactly one company under review", () => {
+        expect(() =>
+            FounderWeeklyReviewScenarioSchema.parse({
+                ...base,
+                companies: [
+                    { name: "A", underReview: true, documents: [] },
+                    { name: "B", underReview: true, documents: [] },
+                ],
+            })
+        ).toThrow(/Exactly one company/);
+        expect(() =>
+            FounderWeeklyReviewScenarioSchema.parse({
+                ...base,
+                companies: [{ name: "A", underReview: false, documents: [] }],
+            })
+        ).toThrow(/Exactly one company/);
+    });
+
+    it("rejects a leakage claim that has nothing to leak from", () => {
+        // One company means the assertion passes vacuously, which reads as
+        // coverage in the fixture while testing nothing.
+        expect(() =>
+            FounderWeeklyReviewScenarioSchema.parse({
+                ...base,
+                expect: { sourceSemantics: { noCrossCompanyLeakage: true } },
+            })
+        ).toThrow(/needs a second, non-under-review company/);
+    });
+
+    it("accepts a leakage claim once a control company exists", () => {
+        const parsed = FounderWeeklyReviewScenarioSchema.parse({
+            ...base,
+            companies: [
+                { name: "Subject", underReview: true, documents: [] },
+                { name: "Control", underReview: false, documents: [] },
+            ],
+            expect: { sourceSemantics: { noCrossCompanyLeakage: true } },
+        });
+        expect(parsed.expect.sourceSemantics?.noCrossCompanyLeakage).toBe(true);
+    });
+
+    it("rejects duplicate version numbers within a document", () => {
+        expect(() =>
+            FounderWeeklyReviewScenarioSchema.parse({
+                ...base,
+                companies: [
+                    {
+                        name: "Northstar Analytics",
+                        underReview: true,
+                        documents: [
+                            {
+                                title: "Plan",
+                                category: "Planning",
+                                versions: [
+                                    { versionNumber: 1, timestamp: "2026-07-21T10:00:00.000Z" },
+                                    { versionNumber: 1, timestamp: "2026-07-22T10:00:00.000Z" },
+                                ],
+                            },
+                        ],
+                    },
+                ],
+            })
+        ).toThrow(/versionNumber must be unique/);
+    });
+
+    it("caps document titles at the database column width", () => {
+        // Review finding: a 512-character title parsed fine and then failed on
+        // INSERT into varchar(256).
+        const parse = (length: number) =>
+            FounderWeeklyReviewScenarioSchema.parse({
+                ...base,
+                companies: [
+                    {
+                        name: "Northstar Analytics",
+                        underReview: true,
+                        documents: [
+                            { title: "t".repeat(length), category: "Planning", versions: [] },
+                        ],
+                    },
+                ],
+            });
+        expect(parse(256).companies[0]!.documents[0]!.title).toHaveLength(256);
+        expect(() => parse(257)).toThrow();
+    });
+
+    it("rejects unknown keys rather than silently ignoring them", () => {
+        expect(() =>
+            FounderWeeklyReviewScenarioSchema.parse({ ...base, unexpected: true })
+        ).toThrow();
+        expect(() =>
+            FounderWeeklyReviewScenarioSchema.parse({
+                ...base,
+                expect: { evidence: { sourceTypeCounts: {} }, misspelled: {} },
+            })
+        ).toThrow();
+    });
+});

--- a/apps/web/__tests__/founderWeeklyReview/scenario-loader.test.ts
+++ b/apps/web/__tests__/founderWeeklyReview/scenario-loader.test.ts
@@ -1,0 +1,39 @@
+/**
+ * Every fixture on disk parses, and each one asserts something. No database
+ * needed — this is the cheap gate that catches a malformed or expectation-free
+ * fixture before the integration suite has to spin up a database to find it.
+ */
+
+import { readdir } from "node:fs/promises";
+import { join } from "node:path";
+
+import { loadScenario, parseScenario } from "../../scripts/founder-weekly-review-scenario-loader";
+
+const SCENARIO_DIR = join(__dirname, "..", "..", "test-fixtures", "founder-weekly-review", "scenarios");
+
+async function scenarioNames(): Promise<string[]> {
+    const entries = await readdir(SCENARIO_DIR, { withFileTypes: true });
+    return entries
+        .filter((entry) => entry.isDirectory())
+        .map((entry) => entry.name)
+        .sort();
+}
+
+describe("founder weekly review scenario loader", () => {
+    it("finds the fixture set on disk", async () => {
+        await expect(scenarioNames()).resolves.not.toHaveLength(0);
+    });
+
+    it("parses every fixture and gives each one a falsifiable expectation", async () => {
+        for (const name of await scenarioNames()) {
+            const scenario = await loadScenario(join(SCENARIO_DIR, name, "scenario.json"));
+            expect(scenario.name).not.toHaveLength(0);
+            expect(Object.keys(scenario.expect).length).toBeGreaterThan(0);
+            expect(scenario.companies.filter((company) => company.underReview)).toHaveLength(1);
+        }
+    });
+
+    it("surfaces a parse failure instead of returning a partial scenario", () => {
+        expect(() => parseScenario({ name: "broken" })).toThrow();
+    });
+});

--- a/apps/web/__tests__/founderWeeklyReview/scenario-seeder.integration.test.ts
+++ b/apps/web/__tests__/founderWeeklyReview/scenario-seeder.integration.test.ts
@@ -1,0 +1,174 @@
+/**
+ * Seeder → collector wiring, on an inline scenario rather than a fixture file.
+ *
+ * The fixture suite proves each committed scenario meets its declared
+ * expectations. This proves the seeder itself puts rows where the collector
+ * looks for them, and covers the one boundary no fixture states outright: a
+ * version dated after the reporting period is seeded but must not be
+ * collected. Keeping it inline means the scenario and its assertions are read
+ * together, which suits a wiring smoke test.
+ *
+ * Ported from #318, whose assertions were sound; only the seeder's return
+ * shape and the default document-change source changed underneath it.
+ */
+
+import { eq } from "drizzle-orm";
+
+import { document } from "@launchstack/core/db/schema";
+import { FounderWeeklyReviewEvidenceService } from "@launchstack/features/founder-weekly-review";
+import { FounderWeeklyReviewDocumentVersionStore } from "~/server/founder-weekly-review/document-version-chunks";
+
+import { parseScenario } from "../../scripts/founder-weekly-review-scenario-loader";
+import { seedScenario } from "../../scripts/founder-weekly-review-scenario-seeder";
+import { createFounderWeeklyReviewTestDatabase } from "./testDb";
+
+const describeIfDatabase =
+    process.env.LAUNCHSTACK_TEST_DATABASE_URL ?? process.env.DATABASE_URL
+        ? describe
+        : describe.skip;
+
+const SCENARIO = parseScenario({
+    name: "seeder-smoke",
+    description:
+        "Every source type at once, plus an out-of-window version and a control company.",
+    reportingPeriod: { start: "2026-07-20", end: "2026-07-26" },
+    workspaceTimezone: "America/New_York",
+    founderContext: "Focus on onboarding reliability.",
+    companies: [
+        {
+            name: "Northstar Analytics",
+            underReview: true,
+            documents: [
+                {
+                    title: "Pricing Page",
+                    category: "Product",
+                    versions: [
+                        {
+                            versionNumber: 1,
+                            timestamp: "2026-07-21T10:00:00.000Z",
+                            changelog: "Baseline inside the window.",
+                            chunks: [{ section: "Tiers", content: "Monthly billing only." }],
+                        },
+                        {
+                            versionNumber: 2,
+                            timestamp: "2026-07-22T10:00:00.000Z",
+                            changelog: "Reworked pricing tiers.",
+                            chunks: [
+                                { section: "Tiers", content: "Monthly and annual billing." },
+                            ],
+                        },
+                        {
+                            versionNumber: 3,
+                            timestamp: "2026-07-28T10:00:00.000Z",
+                            changelog: "Post-window tweak; must be excluded.",
+                            chunks: [
+                                { section: "Tiers", content: "Monthly, annual, and usage-based." },
+                            ],
+                        },
+                    ],
+                },
+                {
+                    title: "Customer Feedback - July",
+                    category: "Customer Feedback",
+                    versions: [
+                        {
+                            versionNumber: 1,
+                            timestamp: "2026-07-23T10:00:00.000Z",
+                            changelog: "Processed customer feedback.",
+                            chunks: [
+                                { section: "Billing", content: "Customers asked for annual billing." },
+                                { section: "SSO", content: "Multiple requests for SSO / SAML." },
+                            ],
+                        },
+                    ],
+                },
+            ],
+        },
+        {
+            name: "Acme (control)",
+            underReview: false,
+            documents: [
+                {
+                    title: "Acme roadmap",
+                    category: "Product",
+                    versions: [
+                        {
+                            versionNumber: 1,
+                            timestamp: "2026-07-22T10:00:00.000Z",
+                            changelog: "Cross-company control; must never appear.",
+                            chunks: [{ section: "Plan", content: "Acme plans a billing rewrite." }],
+                        },
+                    ],
+                },
+            ],
+        },
+    ],
+    expect: {
+        evidence: { sourceTypeCounts: { customer_feedback: { exact: 2 } } },
+        sourceSemantics: { noCrossCompanyLeakage: true },
+    },
+});
+
+describeIfDatabase("seedScenario -> collector", () => {
+    jest.setTimeout(120_000);
+
+    it("seeds a scenario the real collector turns into the expected snapshot", async () => {
+        const testDb = await createFounderWeeklyReviewTestDatabase();
+        try {
+            const { underReviewCompanyId, companyNamesToId } = await seedScenario(
+                testDb.db,
+                SCENARIO
+            );
+
+            const snapshot = await new FounderWeeklyReviewEvidenceService(
+                testDb.db,
+                () => new Date("2026-07-27T00:00:00.000Z"),
+                { kind: "computed", store: new FounderWeeklyReviewDocumentVersionStore(testDb.db) }
+            ).collectFounderWeeklyReviewEvidence({
+                companyId: underReviewCompanyId,
+                reportingPeriod: SCENARIO.reportingPeriod,
+                workspaceTimezone: SCENARIO.workspaceTimezone,
+                founderContext: SCENARIO.founderContext,
+                actor: { externalUserId: "scenario-runner" },
+                requestKey: "scenario-seeder-smoke",
+                capturedAt: new Date("2026-07-27T00:00:00.000Z"),
+            });
+
+            const itemsOfType = (sourceType: string) =>
+                snapshot.items.filter((item) => item.sourceType === sourceType);
+
+            // The in-window v1 -> v2 pair is comparable, so it yields change evidence.
+            expect(itemsOfType("document_change").map((item) => item.title)).toEqual(["Pricing Page"]);
+
+            // One customer_feedback item per processed section.
+            const feedback = itemsOfType("customer_feedback");
+            expect(feedback).toHaveLength(2);
+            expect(feedback.every((item) => item.title === "Customer Feedback - July")).toBe(true);
+
+            expect(itemsOfType("founder_context")).toHaveLength(1);
+
+            // The post-window version is seeded but out of scope. Asserted on the
+            // excerpt, because the document itself legitimately appears via the
+            // in-window pair — only v3's content must be absent.
+            const excerpts = snapshot.items.map((item) => item.excerpt).join("\n");
+            expect(excerpts).not.toContain("usage-based");
+            expect(excerpts).not.toContain("Post-window tweak");
+
+            // Cross-company isolation, with a positive control: the rows exist,
+            // so their absence from the snapshot is filtering rather than a
+            // seeder that never wrote them.
+            expect(snapshot.items.some((item) => item.title === "Acme roadmap")).toBe(false);
+            const controlId = companyNamesToId.get("Acme (control)")!;
+            const controlDocs = await testDb.db
+                .select()
+                .from(document)
+                .where(eq(document.companyId, controlId));
+            expect(controlDocs.length).toBeGreaterThan(0);
+
+            const sourceIds = snapshot.items.map((item) => item.sourceId);
+            expect(new Set(sourceIds).size).toBe(sourceIds.length);
+        } finally {
+            await testDb.close();
+        }
+    });
+});

--- a/apps/web/__tests__/founderWeeklyReview/testDb.ts
+++ b/apps/web/__tests__/founderWeeklyReview/testDb.ts
@@ -69,6 +69,45 @@ async function createSession(
     };
 }
 
+const LOCAL_HOSTS = new Set(["localhost", "127.0.0.1", "::1", "[::1]", "0.0.0.0", "postgres", "db"]);
+
+/** Escape hatch for a sandboxed non-local runner. Opt-in, never inferred. */
+const ALLOW_NON_LOCAL = "LAUNCHSTACK_ALLOW_NON_LOCAL_TEST_DATABASE";
+
+/**
+ * Refuse to run against anything but a local server.
+ *
+ * This helper issues `CREATE DATABASE` and, on the way out, `DROP DATABASE …
+ * WITH (FORCE)`. Pointed at a shared or production host by a stray
+ * `DATABASE_URL` — the variable a developer most likely already has exported —
+ * that is a destructive operation against real data, and nothing downstream
+ * would stop it. Checking merely that *a* URL exists is not a safety check.
+ *
+ * CI is unaffected: its Postgres service is reached over localhost.
+ */
+export function assertLocalTestServer(connectionString: string): void {
+    if (process.env[ALLOW_NON_LOCAL] === "1") return;
+
+    let host: string;
+    try {
+        host = new URL(connectionString).hostname;
+    } catch {
+        throw new Error(
+            `Could not parse the test database URL, so its host cannot be confirmed local. ` +
+                `Set ${ALLOW_NON_LOCAL}=1 only if you are certain the target is disposable.`
+        );
+    }
+
+    if (!LOCAL_HOSTS.has(host)) {
+        throw new Error(
+            `Refusing to run founder weekly review integration tests against non-local host "${host}". ` +
+                `These suites CREATE and DROP databases on the target server. ` +
+                `Point LAUNCHSTACK_TEST_DATABASE_URL at a local Postgres, or set ${ALLOW_NON_LOCAL}=1 ` +
+                `if the target is a disposable sandbox.`
+        );
+    }
+}
+
 /**
  * Spins up a throwaway database and migrates it with both sets.
  *
@@ -86,6 +125,8 @@ export async function createFounderWeeklyReviewTestDatabase(): Promise<FounderWe
             "LAUNCHSTACK_TEST_DATABASE_URL or DATABASE_URL is required for founder weekly review integration tests."
         );
     }
+
+    assertLocalTestServer(connectionString);
 
     const databaseName = `lau6_${randomUUID().replace(/-/g, "")}`;
     const maintenance = postgres(connectionString, { max: 1 });

--- a/apps/web/scripts/founder-weekly-review-scenario-loader.ts
+++ b/apps/web/scripts/founder-weekly-review-scenario-loader.ts
@@ -1,0 +1,14 @@
+import { readFile } from "node:fs/promises";
+
+import {
+    FounderWeeklyReviewScenarioSchema,
+    type FounderWeeklyReviewScenario,
+} from "../test-fixtures/founder-weekly-review/scenarios/contracts";
+
+export function parseScenario(input: unknown): FounderWeeklyReviewScenario {
+    return FounderWeeklyReviewScenarioSchema.parse(input);
+}
+
+export async function loadScenario(path: string): Promise<FounderWeeklyReviewScenario> {
+    return parseScenario(JSON.parse(await readFile(path, "utf8")));
+}

--- a/apps/web/scripts/founder-weekly-review-scenario-seeder.ts
+++ b/apps/web/scripts/founder-weekly-review-scenario-seeder.ts
@@ -1,0 +1,162 @@
+import { createHash } from "node:crypto";
+
+import type { DbClient } from "@launchstack/core/db";
+import {
+    company,
+    document,
+    documentContextChunks,
+    documentStructure,
+    documentVersions,
+} from "@launchstack/core/db/schema";
+import { eq, sql } from "drizzle-orm";
+
+import type { FounderWeeklyReviewScenario } from "../test-fixtures/founder-weekly-review/scenarios/contracts";
+
+export interface SeededScenario {
+    companyNamesToId: Map<string, bigint>;
+    underReviewCompanyId: bigint;
+    /** Document ids per company name — what the leakage assertion checks against. */
+    documentIdsByCompanyName: Map<string, bigint[]>;
+    /** Document titles per company name, for the same purpose. */
+    documentTitlesByCompanyName: Map<string, string[]>;
+}
+
+export type ScenarioSeederOptions = { deterministicWorkspaceEmbeddings?: boolean };
+
+const workspaceVector = () => Array.from({ length: 1536 }, (_, index) => (index === 0 ? 1 : 0));
+const contentHash = (content: string) => createHash("sha256").update(content, "utf8").digest("hex");
+
+const structurePath = (section: string, index: number) =>
+    `/${section.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "") || "section"}-${index + 1}`;
+
+/**
+ * Storage URLs derived from a hash, not from the title.
+ *
+ * `document.url` is varchar(256) while a title may be up to 256 characters on
+ * its own, so a `local://${title}` URL overflows the column for titles the
+ * scenario contract accepts. Hashing decouples the two: the URL is a fixed 39
+ * characters whatever the title is, and stays stable for a given
+ * (company, title, version) so a re-seed produces the same rows.
+ */
+function documentUrl(companyName: string, title: string): string {
+    return `local://doc/${contentHash(`${companyName}\u0000${title}`).slice(0, 24)}`;
+}
+
+function versionUrl(companyName: string, title: string, versionNumber: number): string {
+    return `${documentUrl(companyName, title)}/v${versionNumber}`;
+}
+
+/** Seeds business state only; the collector computes evidence from these rows. */
+export async function seedScenario(
+    db: DbClient,
+    scenario: FounderWeeklyReviewScenario,
+    options: ScenarioSeederOptions = {}
+): Promise<SeededScenario> {
+    const companyNamesToId = new Map<string, bigint>();
+    const documentIdsByCompanyName = new Map<string, bigint[]>();
+    const documentTitlesByCompanyName = new Map<string, string[]>();
+    let underReviewCompanyId: bigint | undefined;
+
+    for (const companyEntry of scenario.companies) {
+        const [companyRow] = await db
+            .insert(company)
+            .values({ name: companyEntry.name, numberOfEmployees: "10" })
+            .returning();
+        const companyId = BigInt(companyRow!.id);
+        companyNamesToId.set(companyEntry.name, companyId);
+        if (companyEntry.underReview) underReviewCompanyId = companyId;
+
+        const documentIds: bigint[] = [];
+        const documentTitles: string[] = [];
+
+        for (const doc of companyEntry.documents) {
+            const [documentRow] = await db
+                .insert(document)
+                .values({
+                    companyId,
+                    url: documentUrl(companyEntry.name, doc.title),
+                    category: doc.category,
+                    title: doc.title,
+                })
+                .returning();
+            const documentId = BigInt(documentRow!.id);
+            documentIds.push(documentId);
+            documentTitles.push(doc.title);
+
+            let latestVersion: { id: bigint; versionNumber: number } | undefined;
+            for (const version of doc.versions) {
+                const [versionRow] = await db
+                    .insert(documentVersions)
+                    .values({
+                        documentId,
+                        versionNumber: version.versionNumber,
+                        url: versionUrl(companyEntry.name, doc.title, version.versionNumber),
+                        mimeType: "text/plain",
+                        uploadedBy: version.uploadedBy ?? "scenario-seed",
+                        changelog: version.changelog ?? null,
+                        createdAt: new Date(version.timestamp),
+                    })
+                    .returning();
+                const versionId = BigInt(versionRow!.id);
+                if (!latestVersion || version.versionNumber > latestVersion.versionNumber) {
+                    latestVersion = { id: versionId, versionNumber: version.versionNumber };
+                }
+
+                for (const [index, chunk] of version.chunks.entries()) {
+                    const [structure] = await db
+                        .insert(documentStructure)
+                        .values({
+                            documentId,
+                            versionId,
+                            ordering: index + 1,
+                            title: chunk.section,
+                            path: structurePath(chunk.section, index),
+                            startPage: chunk.pageNumber ?? index + 1,
+                            endPage: chunk.pageNumber ?? index + 1,
+                        })
+                        .returning();
+                    const values = {
+                        documentId,
+                        versionId,
+                        structureId: BigInt(structure!.id),
+                        content: chunk.content,
+                        contentHash: contentHash(chunk.content),
+                        tokenCount: chunk.content.split(/\s+/).length,
+                        charCount: chunk.content.length,
+                        pageNumber: chunk.pageNumber ?? index + 1,
+                        lineStart: chunk.lineStart ?? 1,
+                        lineEnd: chunk.lineEnd ?? chunk.lineStart ?? 1,
+                    };
+                    await db.insert(documentContextChunks).values(
+                        options.deterministicWorkspaceEmbeddings
+                            ? {
+                                  ...values,
+                                  embedding: sql`${JSON.stringify(workspaceVector())}::vector(1536)`,
+                              }
+                            : values
+                    );
+                }
+            }
+
+            if (latestVersion) {
+                await db
+                    .update(document)
+                    .set({ currentVersionId: latestVersion.id })
+                    .where(eq(document.id, documentRow!.id));
+            }
+        }
+
+        documentIdsByCompanyName.set(companyEntry.name, documentIds);
+        documentTitlesByCompanyName.set(companyEntry.name, documentTitles);
+    }
+
+    if (!underReviewCompanyId) {
+        throw new Error("scenario has no under-review company (expected exactly one).");
+    }
+    return {
+        companyNamesToId,
+        underReviewCompanyId,
+        documentIdsByCompanyName,
+        documentTitlesByCompanyName,
+    };
+}

--- a/apps/web/test-fixtures/founder-weekly-review/scenarios/01-empty-evidence/scenario.json
+++ b/apps/web/test-fixtures/founder-weekly-review/scenarios/01-empty-evidence/scenario.json
@@ -1,0 +1,45 @@
+{
+  "name": "empty-evidence",
+  "description": "No in-window versions and no founder context produce an empty evidence snapshot, and the review is built as all-no_evidence without calling a model.",
+  "reportingPeriod": { "start": "2026-07-20", "end": "2026-07-26" },
+  "workspaceTimezone": "America/New_York",
+  "companies": [
+    {
+      "name": "Northstar Analytics",
+      "underReview": true,
+      "documents": [
+        {
+          "title": "Legacy Handbook",
+          "category": "Reference",
+          "versions": [
+            {
+              "versionNumber": 1,
+              "timestamp": "2026-05-01T10:00:00.000Z",
+              "changelog": "Outside the reporting period.",
+              "chunks": []
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "expect": {
+    "evidence": {
+      "sourceTypeCounts": {
+        "document_change": { "exact": 0 },
+        "workspace_document": { "exact": 0 },
+        "customer_feedback": { "exact": 0 },
+        "founder_context": { "exact": 0 }
+      }
+    },
+    "review": {
+      "sectionStates": {
+        "whatChanged": "no_evidence",
+        "whatShipped": "no_evidence",
+        "whatCustomersSaid": "no_evidence",
+        "currentBlockers": "no_evidence",
+        "nextPriorities": "no_evidence"
+      }
+    }
+  }
+}

--- a/apps/web/test-fixtures/founder-weekly-review/scenarios/02-founder-context-only/scenario.json
+++ b/apps/web/test-fixtures/founder-weekly-review/scenarios/02-founder-context-only/scenario.json
@@ -1,0 +1,22 @@
+{
+  "name": "founder-context-only",
+  "description": "Founder Context is the only collected source. It is founder-provided direction, not customer testimony, so no customer_feedback item may appear.",
+  "reportingPeriod": { "start": "2026-07-20", "end": "2026-07-26" },
+  "workspaceTimezone": "America/New_York",
+  "founderContext": "Focus on onboarding reliability and the billing revamp decision.",
+  "companies": [{ "name": "Northstar Analytics", "underReview": true, "documents": [] }],
+  "expect": {
+    "evidence": {
+      "sourceTypeCounts": {
+        "founder_context": { "exact": 1 },
+        "document_change": { "exact": 0 },
+        "workspace_document": { "exact": 0 },
+        "customer_feedback": { "exact": 0 }
+      }
+    },
+    "sourceSemantics": {
+      "customerFeedbackOnly": true,
+      "temporalEvidenceRequired": true
+    }
+  }
+}

--- a/apps/web/test-fixtures/founder-weekly-review/scenarios/03-relevant-workspace-document/scenario.json
+++ b/apps/web/test-fixtures/founder-weekly-review/scenarios/03-relevant-workspace-document/scenario.json
@@ -1,0 +1,48 @@
+{
+  "name": "relevant-workspace-document",
+  "description": "An unchanged current document is retrieved for Founder Context without becoming a temporal document change.",
+  "reportingPeriod": { "start": "2026-07-20", "end": "2026-07-26" },
+  "workspaceTimezone": "America/New_York",
+  "founderContext": "Focus on onboarding reliability and who owns retry telemetry.",
+  "companies": [
+    {
+      "name": "Northstar Analytics",
+      "underReview": true,
+      "documents": [
+        {
+          "title": "Onboarding Reliability Plan",
+          "category": "Planning",
+          "versions": [
+            {
+              "versionNumber": 1,
+              "timestamp": "2026-06-15T10:00:00.000Z",
+              "changelog": "Last updated before the reporting period.",
+              "chunks": [
+                {
+                  "section": "Ownership",
+                  "content": "Platform owns retry telemetry and recovery monitoring for onboarding."
+                },
+                {
+                  "section": "Runbook",
+                  "content": "On failure, onboarding retries with backoff and pages the platform on-call."
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "expect": {
+    "evidence": {
+      "sourceTypeCounts": {
+        "workspace_document": { "min": 1 },
+        "document_change": { "exact": 0 }
+      }
+    },
+    "sourceSemantics": {
+      "currentWorkspaceOnly": true,
+      "temporalEvidenceRequired": true
+    }
+  }
+}

--- a/apps/web/test-fixtures/founder-weekly-review/scenarios/04-first-ever-version-no-invented-diff/scenario.json
+++ b/apps/web/test-fixtures/founder-weekly-review/scenarios/04-first-ever-version-no-invented-diff/scenario.json
@@ -1,0 +1,39 @@
+{
+  "name": "first-ever-version-no-invented-diff",
+  "description": "A first-ever in-window version has no predecessor. The collector must report the missing baseline rather than invent a diff against nothing.",
+  "reportingPeriod": { "start": "2026-07-20", "end": "2026-07-26" },
+  "workspaceTimezone": "America/New_York",
+  "founderContext": "Review onboarding ownership.",
+  "companies": [
+    {
+      "name": "Northstar Analytics",
+      "underReview": true,
+      "documents": [
+        {
+          "title": "Onboarding Plan",
+          "category": "Planning",
+          "versions": [
+            {
+              "versionNumber": 1,
+              "timestamp": "2026-07-24T10:00:00.000Z",
+              "changelog": "Documented retry telemetry ownership.",
+              "chunks": [
+                {
+                  "section": "Ownership",
+                  "content": "Platform owns retry telemetry and recovery monitoring."
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "expect": {
+    "evidence": {
+      "sourceTypeCounts": { "document_change": { "exact": 0 } },
+      "warningCodes": ["document_change_baseline_missing"]
+    },
+    "sourceSemantics": { "temporalEvidenceRequired": true }
+  }
+}

--- a/apps/web/test-fixtures/founder-weekly-review/scenarios/05-multiple-versions-in-period/scenario.json
+++ b/apps/web/test-fixtures/founder-weekly-review/scenarios/05-multiple-versions-in-period/scenario.json
@@ -1,0 +1,63 @@
+{
+  "name": "multiple-versions-in-period",
+  "description": "A pre-window baseline and three adjacent in-window versions exercise pair chaining and chunk alignment. Four document_change items, not three: alignment emits one item per changed chunk, not per version, and the v3->v4 pair both removes the Ownership chunk and adds a Runbook one. The pre-window v1 is the comparison point, so no baseline-missing warning is reported.",
+  "reportingPeriod": { "start": "2026-07-20", "end": "2026-07-26" },
+  "workspaceTimezone": "America/New_York",
+  "founderContext": "Track how ownership of retry telemetry changed this week.",
+  "companies": [
+    {
+      "name": "Northstar Analytics",
+      "underReview": true,
+      "documents": [
+        {
+          "title": "Onboarding Reliability Plan",
+          "category": "Planning",
+          "versions": [
+            {
+              "versionNumber": 1,
+              "timestamp": "2026-07-10T10:00:00.000Z",
+              "changelog": "Baseline before the reporting window.",
+              "chunks": [{ "section": "Ownership", "content": "Product owns retry telemetry." }]
+            },
+            {
+              "versionNumber": 2,
+              "timestamp": "2026-07-21T10:00:00.000Z",
+              "changelog": "Moved retry telemetry ownership to Platform.",
+              "chunks": [{ "section": "Ownership", "content": "Platform owns retry telemetry." }]
+            },
+            {
+              "versionNumber": 3,
+              "timestamp": "2026-07-23T10:00:00.000Z",
+              "changelog": "Added recovery monitoring to Platform ownership.",
+              "chunks": [
+                {
+                  "section": "Ownership",
+                  "content": "Platform owns retry telemetry and recovery monitoring."
+                }
+              ]
+            },
+            {
+              "versionNumber": 4,
+              "timestamp": "2026-07-25T10:00:00.000Z",
+              "changelog": "Clarified on-call paging.",
+              "chunks": [
+                { "section": "Runbook", "content": "On failure, page the Platform on-call." }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "expect": {
+    "evidence": {
+      "sourceTypeCounts": {
+        "document_change": { "exact": 4 },
+        "founder_context": { "exact": 1 },
+        "customer_feedback": { "exact": 0 }
+      },
+      "forbiddenWarningCodes": ["document_change_baseline_missing"]
+    },
+    "sourceSemantics": { "temporalEvidenceRequired": true }
+  }
+}

--- a/apps/web/test-fixtures/founder-weekly-review/scenarios/06-customer-feedback/scenario.json
+++ b/apps/web/test-fixtures/founder-weekly-review/scenarios/06-customer-feedback/scenario.json
@@ -1,0 +1,67 @@
+{
+  "name": "customer-feedback",
+  "description": "A Customer Feedback document with three chunks (one customer_feedback item per chunk) alongside a Product document change. Exercises the chunk-based customer_feedback path plus document_change in the same run.",
+  "reportingPeriod": { "start": "2026-07-20", "end": "2026-07-26" },
+  "workspaceTimezone": "America/New_York",
+  "founderContext": "Summarize what customers said about billing, onboarding, and SSO this week.",
+  "companies": [
+    {
+      "name": "Northstar Analytics",
+      "underReview": true,
+      "documents": [
+        {
+          "title": "Pricing Page",
+          "category": "Product",
+          "versions": [
+            {
+              "versionNumber": 1,
+              "timestamp": "2026-07-22T10:00:00.000Z",
+              "changelog": "Reworked pricing tiers and added an annual billing option.",
+              "chunks": []
+            }
+          ]
+        },
+        {
+          "title": "Customer Interviews - July 2026",
+          "category": "Customer Feedback",
+          "versions": [
+            {
+              "versionNumber": 1,
+              "timestamp": "2026-07-23T10:00:00.000Z",
+              "changelog": "Processed July customer interviews.",
+              "chunks": [
+                {
+                  "section": "Billing",
+                  "content": "Several customers asked for annual billing instead of monthly-only."
+                },
+                {
+                  "section": "Onboarding",
+                  "content": "Onboarding occasionally retries before completing and needs clearer recovery feedback."
+                },
+                {
+                  "section": "Access",
+                  "content": "Multiple requests for SSO / SAML so larger teams can roll out access."
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "expect": {
+    "evidence": {
+      "sourceTypeCounts": {
+        "customer_feedback": { "exact": 3 },
+        "founder_context": { "exact": 1 },
+        "document_change": { "exact": 0 }
+      },
+      "warningCodes": ["document_change_baseline_missing"],
+      "forbiddenWarningCodes": ["customer_feedback_unavailable", "customer_feedback_missing_sections"]
+    },
+    "sourceSemantics": {
+      "customerFeedbackOnly": true,
+      "temporalEvidenceRequired": true
+    }
+  }
+}

--- a/apps/web/test-fixtures/founder-weekly-review/scenarios/09-cross-company-isolation/scenario.json
+++ b/apps/web/test-fixtures/founder-weekly-review/scenarios/09-cross-company-isolation/scenario.json
@@ -1,0 +1,91 @@
+{
+  "name": "cross-company-isolation",
+  "description": "A subject company under review plus a separate control company. Only the subject's evidence may appear, even though the control's documents sit in the same database inside the same reporting period. The control owns the only Customer Feedback document, so the expected customer_feedback_unavailable warning is itself an isolation signal: the subject genuinely has none, and a leak would both raise the count and silence the warning.",
+  "reportingPeriod": { "start": "2026-07-20", "end": "2026-07-26" },
+  "workspaceTimezone": "America/New_York",
+  "founderContext": "Review Northstar's onboarding work this week.",
+  "companies": [
+    {
+      "name": "Northstar Analytics",
+      "underReview": true,
+      "documents": [
+        {
+          "title": "Onboarding Plan",
+          "category": "Planning",
+          "versions": [
+            {
+              "versionNumber": 1,
+              "timestamp": "2026-07-21T10:00:00.000Z",
+              "changelog": "Baseline before the in-window revision.",
+              "chunks": [{ "section": "Ownership", "content": "Product owns retry telemetry." }]
+            },
+            {
+              "versionNumber": 2,
+              "timestamp": "2026-07-22T10:00:00.000Z",
+              "changelog": "Documented retry telemetry ownership.",
+              "chunks": [{ "section": "Ownership", "content": "Platform owns retry telemetry." }]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Rival Corp",
+      "underReview": false,
+      "documents": [
+        {
+          "title": "Rival roadmap",
+          "category": "Product",
+          "versions": [
+            {
+              "versionNumber": 1,
+              "timestamp": "2026-07-21T10:00:00.000Z",
+              "changelog": "Rival baseline.",
+              "chunks": [{ "section": "Plan", "content": "Rival Corp plans a billing rewrite." }]
+            },
+            {
+              "versionNumber": 2,
+              "timestamp": "2026-07-22T10:00:00.000Z",
+              "changelog": "Belongs to a different company; must never appear in Northstar's review.",
+              "chunks": [
+                { "section": "Plan", "content": "Rival Corp shipped the billing rewrite." }
+              ]
+            }
+          ]
+        },
+        {
+          "title": "Rival Customer Calls",
+          "category": "Customer Feedback",
+          "versions": [
+            {
+              "versionNumber": 1,
+              "timestamp": "2026-07-23T10:00:00.000Z",
+              "changelog": "Rival's processed customer calls.",
+              "chunks": [
+                {
+                  "section": "Billing",
+                  "content": "Rival Corp customers asked for usage-based billing."
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "expect": {
+    "evidence": {
+      "sourceTypeCounts": {
+        "document_change": { "exact": 1 },
+        "customer_feedback": { "exact": 0 },
+        "founder_context": { "exact": 1 }
+      },
+      "warningCodes": ["customer_feedback_unavailable"]
+    },
+    "sourceSemantics": {
+      "noCrossCompanyLeakage": true,
+      "customerFeedbackOnly": true,
+      "temporalEvidenceRequired": true
+    }
+  }
+}

--- a/apps/web/test-fixtures/founder-weekly-review/scenarios/contracts.ts
+++ b/apps/web/test-fixtures/founder-weekly-review/scenarios/contracts.ts
@@ -1,0 +1,256 @@
+/**
+ * Founder Weekly Review scenario fixtures: inputs *and* expected results.
+ *
+ * A scenario describes a world to seed (companies, documents, versions,
+ * chunks) and, in `expect`, what collecting evidence over that world must
+ * produce. The expectations are the point. A fixture that only describes
+ * inputs cannot fail — the cross-company isolation scenario would "pass"
+ * while another company's evidence leaked into the snapshot — so `expect` is
+ * required, and every field in it is asserted by
+ * `__tests__/founderWeeklyReview/scenario-collection.integration.test.ts`.
+ *
+ * The vocabulary here is deliberately limited to what the shipped evidence
+ * snapshot (`founder-weekly-review-evidence/v1`) actually exposes: source-type
+ * counts, warning codes, and the semantic invariants derivable from item
+ * metadata. Two things a reader might expect are absent on purpose:
+ *
+ *   - Document-change *grouping* assertions (group counts, per-group
+ *     categories, "no invented baseline" as a group-level claim) need the
+ *     `documentChangeAudit` block from evidence snapshot v2, which this
+ *     codebase does not emit. The baseline case is still covered here through
+ *     `warningCodes` + a `document_change` count of zero.
+ *   - Review *content* assertions (required/forbidden themes) need a model
+ *     call. `review.sectionStates` is supported because the empty-evidence
+ *     path builds its review without one; anything richer would be asserting
+ *     a stub.
+ *
+ * Add a field here only alongside the assertion that enforces it.
+ */
+
+import { z } from "zod";
+
+import {
+    ReportingPeriodSchema,
+    type FounderWeeklyReviewEvidenceItem,
+} from "@launchstack/features/founder-weekly-review";
+
+export const FOUNDER_WEEKLY_REVIEW_SCENARIO_SCHEMA_VERSION =
+    "founder-weekly-review-scenario/v1" as const;
+
+/**
+ * Column widths from `packages/core/src/db/schema/base.ts`. The contract caps
+ * match the database exactly so a schema-valid fixture cannot fail at seeding
+ * time — the failure mode where a 512-character title parses fine and then
+ * blows up on INSERT.
+ */
+const DB_COMPANY_NAME_MAX = 256;
+const DB_DOCUMENT_TITLE_MAX = 256;
+const DB_DOCUMENT_CATEGORY_MAX = 256;
+const DB_UPLOADED_BY_MAX = 256;
+
+const ScenarioSourceTypeSchema = z.enum([
+    "workspace_document",
+    "document_change",
+    "customer_feedback",
+    "github_activity",
+    "manual_note",
+    "founder_context",
+    "other",
+]);
+export type ScenarioSourceType = z.infer<typeof ScenarioSourceTypeSchema>;
+
+const ScenarioSectionNameSchema = z.enum([
+    "whatChanged",
+    "whatShipped",
+    "whatCustomersSaid",
+    "currentBlockers",
+    "nextPriorities",
+]);
+export type ScenarioSectionName = z.infer<typeof ScenarioSectionNameSchema>;
+
+const CountExpectationSchema = z
+    .object({
+        min: z.number().int().nonnegative().optional(),
+        max: z.number().int().nonnegative().optional(),
+        exact: z.number().int().nonnegative().optional(),
+    })
+    .strict()
+    .superRefine((value, ctx) => {
+        if (value.min === undefined && value.max === undefined && value.exact === undefined) {
+            ctx.addIssue({
+                code: z.ZodIssueCode.custom,
+                message: "a count expectation must constrain something: set min, max, or exact",
+            });
+        }
+        if (value.min !== undefined && value.max !== undefined && value.min > value.max) {
+            ctx.addIssue({ code: z.ZodIssueCode.custom, message: "min must not exceed max" });
+        }
+        if (
+            value.exact !== undefined &&
+            ((value.min !== undefined && value.exact < value.min) ||
+                (value.max !== undefined && value.exact > value.max))
+        ) {
+            ctx.addIssue({ code: z.ZodIssueCode.custom, message: "exact must satisfy min/max" });
+        }
+    });
+export type ScenarioCountExpectation = z.infer<typeof CountExpectationSchema>;
+
+export const ScenarioExpectSchema = z
+    .object({
+        evidence: z
+            .object({
+                /** Per-source-type item counts in the collected snapshot. */
+                sourceTypeCounts: z
+                    .record(ScenarioSourceTypeSchema, CountExpectationSchema)
+                    .optional(),
+                /** Warning codes the snapshot must report. */
+                warningCodes: z.array(z.string().min(1).max(64)).max(32).optional(),
+                /** Warning codes the snapshot must not report. */
+                forbiddenWarningCodes: z.array(z.string().min(1).max(64)).max(32).optional(),
+            })
+            .strict()
+            .optional(),
+        sourceSemantics: z
+            .object({
+                /**
+                 * Only `customer_feedback` items may carry customer testimony —
+                 * asserted as: no other source type is sourced from a document
+                 * in the Customer Feedback category.
+                 */
+                customerFeedbackOnly: z.boolean().optional(),
+                /** Every `document_change` item carries a `sourceTimestamp`. */
+                temporalEvidenceRequired: z.boolean().optional(),
+                /**
+                 * No item references a document owned by a company other than
+                 * the one under review. Requires a second, non-under-review
+                 * company in `companies` to be a real test.
+                 */
+                noCrossCompanyLeakage: z.boolean().optional(),
+                /**
+                 * Retrieved `workspace_document` items are current-state reads,
+                 * so they must not double as temporal change evidence.
+                 */
+                currentWorkspaceOnly: z.boolean().optional(),
+            })
+            .strict()
+            .optional(),
+        review: z
+            .object({
+                /**
+                 * Section states of the generated review. Only assertable when
+                 * generation is deterministic — today that means the
+                 * empty-evidence path, which builds its review without calling
+                 * a model. The harness fails if a fixture declares this and
+                 * generation would need one.
+                 */
+                sectionStates: z
+                    .record(ScenarioSectionNameSchema, z.enum(["evidence", "no_evidence"]))
+                    .optional(),
+            })
+            .strict()
+            .optional(),
+    })
+    .strict()
+    .superRefine((value, ctx) => {
+        if (Object.keys(value).length === 0) {
+            ctx.addIssue({
+                code: z.ZodIssueCode.custom,
+                message: "expect must assert something; an empty expect block cannot fail",
+            });
+        }
+    });
+export type FounderWeeklyReviewScenarioExpect = z.infer<typeof ScenarioExpectSchema>;
+
+export const ScenarioChunkSchema = z
+    .object({
+        section: z.string().min(1).max(256),
+        content: z.string().min(1).max(2000),
+        pageNumber: z.number().int().positive().optional(),
+        lineStart: z.number().int().positive().optional(),
+        lineEnd: z.number().int().positive().optional(),
+    })
+    .strict();
+export type FounderWeeklyReviewScenarioChunk = z.infer<typeof ScenarioChunkSchema>;
+
+export const ScenarioVersionSchema = z
+    .object({
+        versionNumber: z.number().int().positive(),
+        timestamp: z.string().datetime({ offset: true }),
+        changelog: z.string().max(1000).optional(),
+        uploadedBy: z.string().min(1).max(DB_UPLOADED_BY_MAX).optional(),
+        chunks: z.array(ScenarioChunkSchema).max(200).default([]),
+    })
+    .strict();
+export type FounderWeeklyReviewScenarioVersion = z.infer<typeof ScenarioVersionSchema>;
+
+export const ScenarioDocumentSchema = z
+    .object({
+        title: z.string().min(1).max(DB_DOCUMENT_TITLE_MAX),
+        category: z.string().min(1).max(DB_DOCUMENT_CATEGORY_MAX),
+        versions: z.array(ScenarioVersionSchema).max(50),
+    })
+    .strict();
+export type FounderWeeklyReviewScenarioDocument = z.infer<typeof ScenarioDocumentSchema>;
+
+export const ScenarioCompanySchema = z
+    .object({
+        name: z.string().min(1).max(DB_COMPANY_NAME_MAX),
+        underReview: z.boolean().default(false),
+        documents: z.array(ScenarioDocumentSchema).max(200).default([]),
+    })
+    .strict();
+export type FounderWeeklyReviewScenarioCompany = z.infer<typeof ScenarioCompanySchema>;
+
+export const FounderWeeklyReviewScenarioSchema = z
+    .object({
+        schemaVersion: z
+            .literal(FOUNDER_WEEKLY_REVIEW_SCENARIO_SCHEMA_VERSION)
+            .default(FOUNDER_WEEKLY_REVIEW_SCENARIO_SCHEMA_VERSION),
+        name: z.string().min(1).max(128),
+        description: z.string().max(1000).optional(),
+        reportingPeriod: ReportingPeriodSchema,
+        workspaceTimezone: z.string().min(1).max(128),
+        founderContext: z.string().min(1).max(1000).optional(),
+        companies: z.array(ScenarioCompanySchema).min(1).max(10),
+        /**
+         * Required, not optional. An expectation-free scenario is the defect
+         * this contract exists to prevent.
+         */
+        expect: ScenarioExpectSchema,
+    })
+    .strict()
+    .superRefine((scenario, ctx) => {
+        const underReview = scenario.companies.filter((company) => company.underReview);
+        if (underReview.length !== 1) {
+            ctx.addIssue({
+                code: z.ZodIssueCode.custom,
+                path: ["companies"],
+                message: "Exactly one company must have underReview: true",
+            });
+        }
+        // A leakage claim with nothing to leak from passes vacuously, which is
+        // worse than not claiming it: it reads as coverage in the fixture.
+        if (scenario.expect.sourceSemantics?.noCrossCompanyLeakage && scenario.companies.length < 2) {
+            ctx.addIssue({
+                code: z.ZodIssueCode.custom,
+                path: ["expect", "sourceSemantics", "noCrossCompanyLeakage"],
+                message:
+                    "noCrossCompanyLeakage needs a second, non-under-review company to assert against",
+            });
+        }
+        for (const [companyIndex, company] of scenario.companies.entries()) {
+            for (const [documentIndex, doc] of company.documents.entries()) {
+                const versionNumbers = doc.versions.map((version) => version.versionNumber);
+                if (new Set(versionNumbers).size !== versionNumbers.length) {
+                    ctx.addIssue({
+                        code: z.ZodIssueCode.custom,
+                        path: ["companies", companyIndex, "documents", documentIndex, "versions"],
+                        message: "versionNumber must be unique within a document",
+                    });
+                }
+            }
+        }
+    });
+export type FounderWeeklyReviewScenario = z.infer<typeof FounderWeeklyReviewScenarioSchema>;
+
+export type ScenarioEvidenceSourceType = FounderWeeklyReviewEvidenceItem["sourceType"];


### PR DESCRIPTION
## Summary

Adds scenario test framework for the Founder Weekly Review. Scenarios
describe a business situation as **data**, seed it into a throwaway local database, and
run the **real** pipeline against it to test the entire actual collector + generation flow.

## Checklist

- [x] Scenario schema.
- [x] Reusable scenario loader.
- [x] Isolated database seeder.
- [x] Generic scenario runner.
- [x] Six to eight high-value scenarios.
- [x] Artifact export.
- [x] README with run instructions.
- [x] At least one complete document version-chain scenario.
- [x] At least one unchanged but Founder Context-relevant workspace-document scenario (produces no evidence yet).

## How to run

```bash
SYNTHETIC_FWR_LOCAL=1 \
LAUNCHSTACK_TEST_DATABASE_URL="postgresql://...localhost:5433..." \
  pnpm --filter @launchstack/web fwr:run-scenarios -- \
  --scenario test-fixtures/founder-weekly-review/scenarios/06-customer-feedback/scenario.json \
  --fake-generation
```

Artifacts land in .artifacts/founder-weekly-review/scenarios/scenario-name

## Testing

- Unit tests for the contract + loader, and a DB-backed integration test that seeds a scenario
and runs the real collector, asserting evidence types, window filtering, and cross-company
isolation.

## Known limitations

- **`03-relevant-workspace-document` produces no evidence yet.** Including relevant `workspace_document`s requires
  comparing the content against the founder context by meaning, requires embeddings and semantic similarity
- **Review evaluation is not integrated yet:** The runner has a marked hook after read-back where the review grader
  will write to `evaluation.json`, but it does not exist as of right now
- **Real-LLM review generation runs are blocked:** an optional `rationale` field exists, violating the provider's strict "every
  property must be required" structured-output rule
