### PR TITLE
chore: remove root .vscode directory

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,5 +1,0 @@
-{
-    "recommendations": [
-        "openai.chatgpt"
-    ]
-}


### PR DESCRIPTION
## Summary

Removes the root `.vscode/` directory. Its only content was `extensions.json` recommending the `openai.chatgpt` extension — an individual editor preference rather than a repo-level requirement.

## Notes

Left the incidental `.vscode` references in place, since they don't depend on the directory existing:

- `.dockerignore`, `.vercelignore`, `apps/web/Dockerfile.prebuilt.dockerignore` — generic ignore entries
- `apps/web/src/server/inngest/functions/processDocument.ts:106` — a path filter applied to uploaded content

## Test plan

No code paths affected; nothing to run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation/editor-only removal with no runtime, security, or data impact.
> 
> **Overview**
> Removes the repository root **`.vscode/extensions.json`**, which only recommended the `openai.chatgpt` VS Code extension. That file was editor-specific preference, not shared project tooling.
> 
> No application or build behavior changes. Other **`.vscode`** mentions in ignores and upload filters stay as-is and do not require this directory.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 85823e78ce046d3c70985fb7c94c9b0f26ecb6e9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->