### PR TITLE
feat(connectors): import Claude Code and Codex knowledge

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -182,6 +182,20 @@ EMBEDDING_SECRETS_KEY=
 # the same value in the service's own environment (TRANSCRIPTION_API_KEY).
 # TRANSCRIPTION_SERVICE_API_KEY="pdr_local_sidecar_key"
 
+# ── Agent Knowledge Connector (optional) ─────────────────────────────
+# Imports the knowledge Claude Code and Codex already keep on disk
+# (CLAUDE.md / AGENTS.md, subagents, slash commands, skills, memories,
+# prompts) into the workspace knowledge base. It reads the filesystem of the
+# machine running the web app, so leave it off on shared hosts — there the
+# server's disk is not the user's disk. Credential files and session
+# transcripts are never read; see packages/features/src/connectors/README.md.
+
+# AGENT_KNOWLEDGE_CONNECTOR_ENABLED="true"
+# Project directories the connector may scan, separated by the platform path
+# delimiter (":" on macOS/Linux, ";" on Windows). Global ~/.claude and
+# ~/.codex are always in scope when the connector is enabled.
+# AGENT_KNOWLEDGE_PROJECT_ROOTS="/Users/me/code/launchstack:/Users/me/code/other"
+
 # ── Document Processing — OCR ────────────────────────────────────────
 
 # Paid cloud providers (optional)

--- a/apps/web/__tests__/connectors/agent-knowledge-policy.test.ts
+++ b/apps/web/__tests__/connectors/agent-knowledge-policy.test.ts
@@ -1,0 +1,92 @@
+/**
+ * The policy layer is what stops a request body from turning the connector
+ * into an arbitrary-filesystem-read endpoint, so its failure mode is a
+ * security failure rather than a broken feature.
+ */
+
+import path from "node:path";
+
+import {
+    configuredProjectRoots,
+    isAgentKnowledgeConnectorEnabled,
+    isWithinRoot,
+    resolveProjectRoots,
+} from "~/server/services/agent-knowledge-policy";
+
+describe("isAgentKnowledgeConnectorEnabled", () => {
+    it("defaults to off", () => {
+        expect(isAgentKnowledgeConnectorEnabled(undefined)).toBe(false);
+        expect(isAgentKnowledgeConnectorEnabled("")).toBe(false);
+        expect(isAgentKnowledgeConnectorEnabled("false")).toBe(false);
+        expect(isAgentKnowledgeConnectorEnabled("0")).toBe(false);
+    });
+
+    it("accepts the usual affirmative spellings", () => {
+        for (const value of ["true", "TRUE", "1", "yes", " on "]) {
+            expect(isAgentKnowledgeConnectorEnabled(value)).toBe(true);
+        }
+    });
+});
+
+describe("configuredProjectRoots", () => {
+    it("is empty when unset", () => {
+        expect(configuredProjectRoots(undefined)).toEqual([]);
+        expect(configuredProjectRoots("  ")).toEqual([]);
+    });
+
+    it("splits on the platform delimiter, resolves and de-duplicates", () => {
+        const raw = ["/srv/a", "/srv/b", "/srv/a", " "].join(path.delimiter);
+        expect(configuredProjectRoots(raw)).toEqual([path.resolve("/srv/a"), path.resolve("/srv/b")]);
+    });
+});
+
+describe("isWithinRoot", () => {
+    it("accepts the root itself and its descendants", () => {
+        expect(isWithinRoot("/srv/app", "/srv/app")).toBe(true);
+        expect(isWithinRoot("/srv/app", "/srv/app/packages/core")).toBe(true);
+    });
+
+    it("rejects siblings and parents", () => {
+        expect(isWithinRoot("/srv/app", "/srv/app-other")).toBe(false);
+        expect(isWithinRoot("/srv/app", "/srv")).toBe(false);
+        expect(isWithinRoot("/srv/app", "/etc")).toBe(false);
+    });
+});
+
+describe("resolveProjectRoots", () => {
+    const roots = [path.resolve("/srv/app"), path.resolve("/srv/other")];
+
+    it("falls back to every configured root when nothing is requested", () => {
+        expect(resolveProjectRoots(undefined, roots)).toEqual({ allowed: roots, rejected: [] });
+        expect(resolveProjectRoots([], roots)).toEqual({ allowed: roots, rejected: [] });
+    });
+
+    it("allows a subdirectory of a configured root", () => {
+        const decision = resolveProjectRoots(["/srv/app/apps/web"], roots);
+        expect(decision.allowed).toEqual([path.resolve("/srv/app/apps/web")]);
+        expect(decision.rejected).toEqual([]);
+    });
+
+    it("rejects a directory outside every root", () => {
+        const decision = resolveProjectRoots(["/etc"], roots);
+        expect(decision.allowed).toEqual([]);
+        expect(decision.rejected).toEqual([path.resolve("/etc")]);
+    });
+
+    it("cannot be escaped with a traversal segment", () => {
+        const decision = resolveProjectRoots(["/srv/app/../../etc"], roots);
+        expect(decision.allowed).toEqual([]);
+        expect(decision.rejected).toEqual([path.resolve("/etc")]);
+    });
+
+    it("rejects everything when no roots are configured", () => {
+        const decision = resolveProjectRoots(["/srv/app"], []);
+        expect(decision.allowed).toEqual([]);
+        expect(decision.rejected).toEqual([path.resolve("/srv/app")]);
+    });
+
+    it("de-duplicates repeated requests", () => {
+        const decision = resolveProjectRoots(["/srv/app", "/srv/app/"], roots);
+        expect(decision.allowed).toEqual([path.resolve("/srv/app")]);
+    });
+});

--- a/apps/web/__tests__/connectors/agent-knowledge-route.test.ts
+++ b/apps/web/__tests__/connectors/agent-knowledge-route.test.ts
@@ -1,0 +1,229 @@
+/**
+ * Route-level gates. The connector reads the server's filesystem, so "who may
+ * call this, and with which directories" is the part that must not regress.
+ */
+
+const mockEnv = {
+    server: {
+        AGENT_KNOWLEDGE_CONNECTOR_ENABLED: undefined as string | undefined,
+        AGENT_KNOWLEDGE_PROJECT_ROOTS: undefined as string | undefined,
+    },
+};
+const mockUserRows: { rows: { id: bigint; role: string; companyId: bigint }[] } = { rows: [] };
+
+// A getter, not `env: mockEnv` — jest hoists mock factories above the const,
+// so the binding is only safe to read once a handler actually runs.
+jest.mock("~/env", () => ({
+    get env() {
+        return mockEnv;
+    },
+}));
+jest.mock("@clerk/nextjs/server", () => ({ auth: jest.fn() }));
+jest.mock("~/server/db", () => ({
+    db: {
+        select: () => ({ from: () => ({ where: () => Promise.resolve(mockUserRows.rows) }) }),
+    },
+}));
+jest.mock("~/lib/active-workspace", () => ({ resolveActiveCompanyForUser: jest.fn() }));
+jest.mock("~/server/services/agent-knowledge-connector", () => ({
+    previewAgentKnowledge: jest.fn(),
+    runAgentKnowledgeSync: jest.fn(),
+}));
+
+import path from "node:path";
+
+import { auth } from "@clerk/nextjs/server";
+
+import { GET, POST } from "~/app/api/connectors/agent-knowledge/route";
+import { resolveActiveCompanyForUser } from "~/lib/active-workspace";
+import {
+    previewAgentKnowledge,
+    runAgentKnowledgeSync,
+} from "~/server/services/agent-knowledge-connector";
+
+const mockAuth = auth as unknown as jest.Mock;
+const mockResolveCompany = resolveActiveCompanyForUser as jest.Mock;
+const mockPreview = previewAgentKnowledge as jest.Mock;
+const mockSync = runAgentKnowledgeSync as jest.Mock;
+
+const ROOT = path.resolve("/srv/checkouts/app");
+
+interface ApiBody {
+    message?: string;
+    data: {
+        counts?: Record<string, number>;
+        rejectedProjects?: string[];
+        items?: { relativePath: string; kind: string }[];
+    };
+}
+
+async function readBody(response: Response): Promise<ApiBody> {
+    return (await response.json()) as ApiBody;
+}
+
+function postRequest(body?: unknown): Request {
+    return new Request("http://test/api/connectors/agent-knowledge", {
+        method: "POST",
+        ...(body === undefined ? {} : { body: JSON.stringify(body) }),
+    });
+}
+
+function getRequest(query = ""): Request {
+    return new Request(`http://test/api/connectors/agent-knowledge${query}`);
+}
+
+beforeEach(() => {
+    jest.clearAllMocks();
+    mockEnv.server.AGENT_KNOWLEDGE_CONNECTOR_ENABLED = "true";
+    mockEnv.server.AGENT_KNOWLEDGE_PROJECT_ROOTS = ROOT;
+    mockUserRows.rows = [{ id: 1n, role: "owner", companyId: 7n }];
+    mockAuth.mockResolvedValue({ userId: "user_abc" });
+    mockResolveCompany.mockResolvedValue(7n);
+    mockPreview.mockResolvedValue({ roots: [], items: [], skipped: [], truncated: false });
+    mockSync.mockResolvedValue({
+        connectorId: "agent-knowledge",
+        startedAt: "2026-08-09T10:00:00.000Z",
+        finishedAt: "2026-08-09T10:00:01.000Z",
+        durationMs: 1000,
+        discovered: 2,
+        stored: [
+            { sourceId: "a", documentId: 1, versionId: 1, jobId: "j1", revised: false },
+            { sourceId: "b", documentId: 2, versionId: 2, jobId: "j2", revised: true },
+        ],
+        skipped: [],
+        failed: [],
+        scan: { roots: [], items: [], skipped: [], truncated: false },
+        truncated: false,
+    });
+});
+
+describe("POST /api/connectors/agent-knowledge", () => {
+    it("rejects an unauthenticated call before touching the filesystem", async () => {
+        mockAuth.mockResolvedValue({ userId: null });
+
+        const response = await POST(postRequest({}));
+
+        expect(response.status).toBe(401);
+        expect(mockSync).not.toHaveBeenCalled();
+    });
+
+    it("rejects an employee — imported knowledge is workspace-wide", async () => {
+        mockUserRows.rows = [{ id: 1n, role: "employee", companyId: 7n }];
+
+        const response = await POST(postRequest({}));
+
+        expect(response.status).toBe(403);
+        expect(mockSync).not.toHaveBeenCalled();
+    });
+
+    it("stays off unless the deployment opts in", async () => {
+        mockEnv.server.AGENT_KNOWLEDGE_CONNECTOR_ENABLED = undefined;
+
+        const response = await POST(postRequest({}));
+
+        expect(response.status).toBe(403);
+        expect((await readBody(response)).message).toContain(
+            "AGENT_KNOWLEDGE_CONNECTOR_ENABLED"
+        );
+        expect(mockSync).not.toHaveBeenCalled();
+    });
+
+    it("syncs with defaults when the body is empty", async () => {
+        const response = await POST(postRequest());
+
+        expect(response.status).toBe(202);
+        const payload = await readBody(response);
+        expect(payload.data.counts).toEqual(
+            expect.objectContaining({ discovered: 2, stored: 2, created: 1, revised: 1 })
+        );
+        expect(mockSync).toHaveBeenCalledWith(
+            expect.objectContaining({
+                companyId: 7n,
+                userId: "user_abc",
+                projects: [{ dir: ROOT }],
+            })
+        );
+    });
+
+    it("refuses project directories outside the configured roots", async () => {
+        const response = await POST(postRequest({ projects: ["/etc"] }));
+
+        expect(response.status).toBe(403);
+        expect(mockSync).not.toHaveBeenCalled();
+    });
+
+    it("refuses a traversal dressed up as an allowed root", async () => {
+        const response = await POST(postRequest({ projects: [`${ROOT}/../../etc`] }));
+
+        expect(response.status).toBe(403);
+        expect(mockSync).not.toHaveBeenCalled();
+    });
+
+    it("passes a subdirectory of an allowed root straight through", async () => {
+        const nested = path.join(ROOT, "apps", "web");
+
+        const response = await POST(postRequest({ projects: [nested] }));
+
+        expect(response.status).toBe(202);
+        expect(mockSync).toHaveBeenCalledWith(
+            expect.objectContaining({ projects: [{ dir: nested }] })
+        );
+    });
+
+    it("rejects a malformed option instead of silently dropping it", async () => {
+        const response = await POST(postRequest({ tools: ["cursor"] }));
+
+        expect(response.status).toBe(400);
+        expect(mockSync).not.toHaveBeenCalled();
+    });
+});
+
+describe("GET /api/connectors/agent-knowledge", () => {
+    it("previews without reading file contents", async () => {
+        mockPreview.mockResolvedValue({
+            roots: [{ toolId: "claude-code", scope: "global", key: "global", dir: "/h/.claude", exists: true, itemCount: 1 }],
+            items: [
+                {
+                    sourceId: "agent-knowledge://claude-code/global/CLAUDE.md",
+                    title: "Claude Code (global) — CLAUDE.md",
+                    kind: "instructions",
+                    bytes: 12,
+                    modifiedAt: "2026-08-01T00:00:00.000Z",
+                    location: { origin: "/h/.claude/CLAUDE.md", relativePath: "CLAUDE.md" },
+                    metadata: {},
+                    connectorId: "agent-knowledge",
+                    mimeType: "text/markdown",
+                },
+            ],
+            skipped: [],
+            truncated: false,
+        });
+
+        const response = await GET(getRequest());
+        const payload = await readBody(response);
+
+        expect(response.status).toBe(200);
+        expect(payload.data.items).toEqual([
+            expect.objectContaining({ relativePath: "CLAUDE.md", kind: "instructions" }),
+        ]);
+        // The preview must not hand back the file's text or its absolute path.
+        expect(JSON.stringify(payload.data.items)).not.toContain("origin");
+        expect(mockSync).not.toHaveBeenCalled();
+    });
+
+    it("reports rejected project directories rather than scanning them", async () => {
+        const response = await GET(getRequest("?projects=/etc"));
+        const payload = await readBody(response);
+
+        expect(response.status).toBe(200);
+        expect(payload.data.rejectedProjects).toEqual([path.resolve("/etc")]);
+        expect(mockPreview).toHaveBeenCalledWith(expect.objectContaining({ projects: [] }));
+    });
+
+    it("requires the same authorization as a sync", async () => {
+        mockUserRows.rows = [{ id: 1n, role: "employee", companyId: 7n }];
+
+        expect((await GET(getRequest())).status).toBe(403);
+        expect(mockPreview).not.toHaveBeenCalled();
+    });
+});

--- a/apps/web/__tests__/connectors/agent-knowledge-scan.test.ts
+++ b/apps/web/__tests__/connectors/agent-knowledge-scan.test.ts
@@ -1,0 +1,327 @@
+/**
+ * Discovery is the connector's security boundary: it decides which files on
+ * the host's disk are eligible to leave it. These tests build a real directory
+ * tree — no fs mocks — so an allowlist change that quietly widens what is
+ * readable fails here.
+ */
+
+import { mkdtemp, mkdir, rm, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import {
+    collectAgentKnowledge,
+    scanAgentKnowledge,
+} from "@launchstack/features/connectors/agent-knowledge";
+
+const NUL = String.fromCharCode(0);
+
+let root: string;
+let home: string;
+let project: string;
+
+async function write(file: string, contents: string): Promise<void> {
+    await mkdir(path.dirname(file), { recursive: true });
+    await writeFile(file, contents, "utf8");
+}
+
+beforeEach(async () => {
+    root = await mkdtemp(path.join(tmpdir(), "agent-knowledge-"));
+    home = path.join(root, "home");
+    project = path.join(root, "workspace", "acme");
+    await mkdir(home, { recursive: true });
+    await mkdir(project, { recursive: true });
+});
+
+afterEach(async () => {
+    await rm(root, { recursive: true, force: true });
+});
+
+function sourceIds(items: readonly { sourceId: string }[]): string[] {
+    return items.map(item => item.sourceId).sort();
+}
+
+describe("scanAgentKnowledge — what it picks up", () => {
+    it("finds Claude Code global knowledge across every allowlisted location", async () => {
+        await write(path.join(home, ".claude", "CLAUDE.md"), "# Global instructions");
+        await write(path.join(home, ".claude", "MEMORY.md"), "- [A memory](a.md)");
+        await write(path.join(home, ".claude", "agents", "reviewer.md"), "You review code.");
+        await write(path.join(home, ".claude", "commands", "ship.md"), "Ship it.");
+        await write(path.join(home, ".claude", "skills", "dataviz", "SKILL.md"), "Charts.");
+        await write(path.join(home, ".claude", "memory", "user-prefers-pnpm.md"), "pnpm.");
+        await write(path.join(home, ".claude", "output-styles", "terse.md"), "Be terse.");
+
+        const scan = await scanAgentKnowledge({ homeDir: home, tools: ["claude-code"] });
+
+        expect(sourceIds(scan.items)).toEqual([
+            "agent-knowledge://claude-code/global/CLAUDE.md",
+            "agent-knowledge://claude-code/global/MEMORY.md",
+            "agent-knowledge://claude-code/global/agents/reviewer.md",
+            "agent-knowledge://claude-code/global/commands/ship.md",
+            "agent-knowledge://claude-code/global/memory/user-prefers-pnpm.md",
+            "agent-knowledge://claude-code/global/output-styles/terse.md",
+            "agent-knowledge://claude-code/global/skills/dataviz/SKILL.md",
+        ]);
+
+        const skill = scan.items.find(item => item.sourceId.endsWith("dataviz/SKILL.md"));
+        expect(skill?.kind).toBe("skill");
+        expect(skill?.mimeType).toBe("text/markdown");
+    });
+
+    it("finds Codex global knowledge", async () => {
+        await write(path.join(home, ".codex", "AGENTS.md"), "# Codex instructions");
+        await write(path.join(home, ".codex", "prompts", "refactor.md"), "Refactor.");
+        await write(path.join(home, ".codex", "memories", "stack.md"), "Postgres.");
+
+        const scan = await scanAgentKnowledge({ homeDir: home, tools: ["codex"] });
+
+        expect(sourceIds(scan.items)).toEqual([
+            "agent-knowledge://codex/global/AGENTS.md",
+            "agent-knowledge://codex/global/memories/stack.md",
+            "agent-knowledge://codex/global/prompts/refactor.md",
+        ]);
+        expect(scan.items.find(item => item.sourceId.endsWith("prompts/refactor.md"))?.kind).toBe(
+            "prompt"
+        );
+    });
+
+    it("scans project scope with a stable, machine-independent key", async () => {
+        await write(path.join(project, "CLAUDE.md"), "# Project rules");
+        await write(path.join(project, "AGENTS.md"), "# Codex project rules");
+        await write(path.join(project, ".claude", "agents", "tester.md"), "You test.");
+
+        const scan = await scanAgentKnowledge({
+            homeDir: home,
+            projects: [{ dir: project }],
+            scopes: ["project"],
+        });
+
+        expect(sourceIds(scan.items)).toEqual([
+            "agent-knowledge://claude-code/acme/.claude/agents/tester.md",
+            "agent-knowledge://claude-code/acme/CLAUDE.md",
+            "agent-knowledge://codex/acme/AGENTS.md",
+        ]);
+        // No absolute path leaks into the identity the host keys documents on.
+        for (const item of scan.items) {
+            expect(item.sourceId).not.toContain(root);
+        }
+    });
+
+    it("keeps two checkouts that share a basename apart when given explicit keys", async () => {
+        const other = path.join(root, "elsewhere", "acme");
+        await write(path.join(project, "CLAUDE.md"), "one");
+        await write(path.join(other, "CLAUDE.md"), "two");
+
+        const scan = await scanAgentKnowledge({
+            homeDir: home,
+            tools: ["claude-code"],
+            scopes: ["project"],
+            projects: [
+                { dir: project, key: "acme-main" },
+                { dir: other, key: "acme-fork" },
+            ],
+        });
+
+        expect(sourceIds(scan.items)).toEqual([
+            "agent-knowledge://claude-code/acme-fork/CLAUDE.md",
+            "agent-knowledge://claude-code/acme-main/CLAUDE.md",
+        ]);
+    });
+
+    it("reports roots that do not exist rather than failing", async () => {
+        const scan = await scanAgentKnowledge({ homeDir: home, tools: ["claude-code"] });
+
+        expect(scan.items).toHaveLength(0);
+        expect(scan.roots).toEqual([
+            expect.objectContaining({ scope: "global", exists: false, itemCount: 0 }),
+        ]);
+    });
+});
+
+describe("scanAgentKnowledge — what it refuses to read", () => {
+    it("never returns credential files that sit inside allowlisted roots", async () => {
+        await write(path.join(home, ".claude", "CLAUDE.md"), "# Instructions");
+        await write(path.join(home, ".claude", "memory", ".credentials.json"), "{}");
+        await write(path.join(home, ".claude", "memory", "api-token.md"), "sk-live-123");
+        await write(path.join(home, ".claude", "memory", "my-secret-notes.md"), "hunter2");
+        await write(path.join(home, ".claude", "memory", "cert.pem"), "-----BEGIN");
+
+        const scan = await scanAgentKnowledge({ homeDir: home, tools: ["claude-code"] });
+
+        expect(sourceIds(scan.items)).toEqual(["agent-knowledge://claude-code/global/CLAUDE.md"]);
+        const excluded = scan.skipped.filter(entry => entry.reason === "excluded");
+        expect(excluded.map(entry => entry.sourceId)).toEqual(
+            expect.arrayContaining([
+                "agent-knowledge://claude-code/global/memory/api-token.md",
+                "agent-knowledge://claude-code/global/memory/my-secret-notes.md",
+            ])
+        );
+    });
+
+    it("leaves config files alone unless includeConfig is set", async () => {
+        await write(path.join(home, ".claude", "settings.json"), '{"model":"opus"}');
+        await write(path.join(home, ".codex", "config.toml"), 'model = "gpt"');
+
+        const withoutConfig = await scanAgentKnowledge({ homeDir: home });
+        expect(withoutConfig.items).toHaveLength(0);
+
+        const withConfig = await scanAgentKnowledge({ homeDir: home, includeConfig: true });
+        expect(sourceIds(withConfig.items)).toEqual([
+            "agent-knowledge://claude-code/global/settings.json",
+            "agent-knowledge://codex/global/config.toml",
+        ]);
+    });
+
+    it("never descends into session transcripts, caches or project state", async () => {
+        await write(path.join(home, ".claude", "memory", "keep.md"), "keep");
+        await write(path.join(home, ".claude", "memory", "cache", "blob.md"), "cached");
+        await write(path.join(home, ".claude", "memory", "sessions", "s1.md"), "transcript");
+        await write(path.join(home, ".claude", "projects", "p", "notes.md"), "state");
+        await write(path.join(home, ".claude", "memory", "history.jsonl"), "{}");
+
+        const scan = await scanAgentKnowledge({ homeDir: home, tools: ["claude-code"] });
+
+        expect(sourceIds(scan.items)).toEqual([
+            "agent-knowledge://claude-code/global/memory/keep.md",
+        ]);
+    });
+
+    it("reads per-project memory without touching the transcripts beside it", async () => {
+        const slug = path.join(home, ".claude", "projects", "-Users-dev-acme");
+        await write(path.join(slug, "memory", "MEMORY.md"), "- [Deploys](deploys.md)");
+        await write(path.join(slug, "memory", "deploys.md"), "Deploys run on Fridays.");
+        // Everything else in that directory is machine state.
+        await write(path.join(slug, "session-1.jsonl"), '{"type":"user"}');
+        await write(path.join(slug, "notes.md"), "not a memory");
+        await write(path.join(slug, "subagent", "transcript.md"), "not a memory");
+
+        const scan = await scanAgentKnowledge({ homeDir: home, tools: ["claude-code"] });
+
+        expect(sourceIds(scan.items)).toEqual([
+            "agent-knowledge://claude-code/global/projects/-Users-dev-acme/memory/MEMORY.md",
+            "agent-knowledge://claude-code/global/projects/-Users-dev-acme/memory/deploys.md",
+        ]);
+        expect(scan.items.every(item => item.kind === "memory")).toBe(true);
+    });
+
+    it("does not follow symlinks out of the root", async () => {
+        const outside = path.join(root, "outside");
+        await write(path.join(outside, "private.md"), "not yours");
+        await mkdir(path.join(home, ".claude", "agents"), { recursive: true });
+        await symlink(path.join(outside, "private.md"), path.join(home, ".claude", "agents", "link.md"));
+        await symlink(outside, path.join(home, ".claude", "agents", "escape"));
+
+        const scan = await scanAgentKnowledge({ homeDir: home, tools: ["claude-code"] });
+
+        expect(scan.items).toHaveLength(0);
+        expect(scan.skipped.map(entry => entry.detail)).toEqual(
+            expect.arrayContaining(["symlink"])
+        );
+    });
+
+    it("skips oversized and empty files with a reason", async () => {
+        await write(path.join(home, ".claude", "agents", "huge.md"), "x".repeat(4096));
+        await write(path.join(home, ".claude", "agents", "blank.md"), "");
+        await write(path.join(home, ".claude", "agents", "ok.md"), "fine");
+
+        const scan = await scanAgentKnowledge({
+            homeDir: home,
+            tools: ["claude-code"],
+            maxFileBytes: 1024,
+        });
+
+        expect(sourceIds(scan.items)).toEqual(["agent-knowledge://claude-code/global/agents/ok.md"]);
+        expect(scan.skipped).toEqual(
+            expect.arrayContaining([
+                expect.objectContaining({
+                    sourceId: "agent-knowledge://claude-code/global/agents/huge.md",
+                    reason: "too-large",
+                }),
+                expect.objectContaining({
+                    sourceId: "agent-knowledge://claude-code/global/agents/blank.md",
+                    reason: "empty",
+                }),
+            ])
+        );
+    });
+
+    it("marks the scan truncated instead of silently dropping the tail", async () => {
+        for (const name of ["a", "b", "c", "d"]) {
+            await write(path.join(home, ".claude", "agents", `${name}.md`), name);
+        }
+
+        const scan = await scanAgentKnowledge({
+            homeDir: home,
+            tools: ["claude-code"],
+            maxItems: 2,
+        });
+
+        expect(scan.items).toHaveLength(2);
+        expect(scan.truncated).toBe(true);
+        expect(scan.skipped.filter(entry => entry.reason === "limit-reached")).toHaveLength(2);
+    });
+
+    it("ignores files whose extension is not text-like", async () => {
+        await write(path.join(home, ".claude", "skills", "viz", "SKILL.md"), "skill");
+        await write(path.join(home, ".claude", "skills", "viz", "chart.png"), "binary-ish");
+        await write(path.join(home, ".claude", "skills", "viz", "run.py"), "print(1)");
+
+        const scan = await scanAgentKnowledge({ homeDir: home, tools: ["claude-code"] });
+
+        expect(sourceIds(scan.items)).toEqual([
+            "agent-knowledge://claude-code/global/skills/viz/SKILL.md",
+        ]);
+    });
+});
+
+describe("collectAgentKnowledge", () => {
+    it("reads contents, normalizes line endings and hashes the result", async () => {
+        await write(path.join(home, ".claude", "CLAUDE.md"), "# Rules\r\n\r\nBe careful.\r\n");
+
+        const scan = await scanAgentKnowledge({ homeDir: home, tools: ["claude-code"] });
+        const collected = await collectAgentKnowledge(scan.items);
+
+        expect(collected.items).toHaveLength(1);
+        expect(collected.items[0]?.content).toBe("# Rules\n\nBe careful.");
+        expect(collected.items[0]?.contentHash).toMatch(/^[0-9a-f]{64}$/);
+    });
+
+    it("gives identical content the same hash across scopes", async () => {
+        await write(path.join(home, ".claude", "CLAUDE.md"), "same text");
+        await write(path.join(project, "CLAUDE.md"), "same text");
+
+        const scan = await scanAgentKnowledge({
+            homeDir: home,
+            tools: ["claude-code"],
+            projects: [{ dir: project }],
+        });
+        const collected = await collectAgentKnowledge(scan.items);
+
+        expect(collected.items).toHaveLength(2);
+        expect(collected.items[0]?.contentHash).toBe(collected.items[1]?.contentHash);
+        expect(collected.items[0]?.sourceId).not.toBe(collected.items[1]?.sourceId);
+    });
+
+    it("refuses a binary file that happens to end in .md", async () => {
+        await write(path.join(home, ".claude", "agents", "binary.md"), `head${NUL}tail`);
+
+        const scan = await scanAgentKnowledge({ homeDir: home, tools: ["claude-code"] });
+        const collected = await collectAgentKnowledge(scan.items);
+
+        expect(collected.items).toHaveLength(0);
+        expect(collected.skipped).toEqual([
+            expect.objectContaining({ reason: "excluded", detail: "binary content" }),
+        ]);
+    });
+
+    it("turns an unreadable file into a skip, not a thrown scan", async () => {
+        await write(path.join(home, ".claude", "CLAUDE.md"), "gone soon");
+        const scan = await scanAgentKnowledge({ homeDir: home, tools: ["claude-code"] });
+        await rm(path.join(home, ".claude", "CLAUDE.md"));
+
+        const collected = await collectAgentKnowledge(scan.items);
+
+        expect(collected.items).toHaveLength(0);
+        expect(collected.skipped).toEqual([expect.objectContaining({ reason: "unreadable" })]);
+    });
+});

--- a/apps/web/__tests__/connectors/agent-knowledge-sink.test.ts
+++ b/apps/web/__tests__/connectors/agent-knowledge-sink.test.ts
@@ -1,0 +1,310 @@
+/**
+ * The sink is where a `KnowledgeItem` becomes a document: first sync creates
+ * one, a changed file adds a version to the *same* document, and an unchanged
+ * file is recognised before anything reaches blob storage.
+ */
+
+const mockEnv = { server: { APP_PUBLIC_URL: undefined as string | undefined } };
+jest.mock("~/env", () => ({
+    get env() {
+        return mockEnv;
+    },
+}));
+jest.mock("~/server/engine", () => ({ getEngine: jest.fn() }));
+jest.mock("~/lib/storage", () => ({ uploadFile: jest.fn() }));
+jest.mock("@launchstack/core/embeddings", () => ({ resolveIngestIndexKey: jest.fn() }));
+jest.mock("~/server/services/document-creation", () => ({
+    createDocumentLifecycle: jest.fn(),
+    createDocumentVersionLifecycle: jest.fn(),
+    findDocumentByCreationKey: jest.fn(),
+}));
+
+const mockUpdateWhere = jest.fn();
+const mockUpdateSet = jest.fn(() => ({ where: mockUpdateWhere }));
+const mockDbUpdate = jest.fn((_table: unknown) => ({ set: mockUpdateSet }));
+jest.mock("~/server/db", () => ({
+    db: { update: (table: unknown) => mockDbUpdate(table) },
+}));
+
+import type { KnowledgeItem } from "@launchstack/features/connectors";
+import { resolveIngestIndexKey } from "@launchstack/core/embeddings";
+
+import { uploadFile } from "~/lib/storage";
+import {
+    createDocumentLifecycle,
+    createDocumentVersionLifecycle,
+    findDocumentByCreationKey,
+} from "~/server/services/document-creation";
+import {
+    AGENT_KNOWLEDGE_CATEGORY,
+    createAgentKnowledgeSink,
+} from "~/server/services/agent-knowledge-connector";
+
+const mockUploadFile = uploadFile as jest.Mock;
+const mockResolveIndex = resolveIngestIndexKey as jest.Mock;
+const mockCreate = createDocumentLifecycle as jest.Mock;
+const mockCreateVersion = createDocumentVersionLifecycle as jest.Mock;
+const mockFind = findDocumentByCreationKey as jest.Mock;
+
+const SOURCE_ID = "agent-knowledge://claude-code/global/agents/code-reviewer.md";
+
+interface UploadArg {
+    filename: string;
+    data: Buffer;
+    contentType: string;
+}
+
+interface LifecycleArg {
+    ocrMetadata: Record<string, unknown>;
+    processing: Record<string, unknown>;
+}
+
+function firstCallArg<T>(mock: jest.Mock): T {
+    const calls = mock.mock.calls as unknown as [T][];
+    const first = calls[0];
+    if (!first) throw new Error("expected the mock to have been called");
+    return first[0];
+}
+
+function knowledgeItem(overrides: Partial<KnowledgeItem> = {}): KnowledgeItem {
+    return {
+        sourceId: SOURCE_ID,
+        connectorId: "agent-knowledge",
+        title: "Claude Code (global) — agents/code-reviewer.md",
+        kind: "agent",
+        mimeType: "text/markdown",
+        bytes: 42,
+        modifiedAt: "2026-08-01T00:00:00.000Z",
+        location: {
+            origin: "/home/dev/.claude/agents/code-reviewer.md",
+            relativePath: "agents/code-reviewer.md",
+        },
+        metadata: {
+            tool: "claude-code",
+            toolLabel: "Claude Code",
+            scope: "global",
+            scopeKey: "global",
+            kind: "agent",
+        },
+        content: "You review code carefully.",
+        contentHash: "a".repeat(64),
+        ...overrides,
+    };
+}
+
+const context = { companyId: 7n, userId: "user_abc" };
+
+beforeEach(() => {
+    jest.clearAllMocks();
+    mockEnv.server.APP_PUBLIC_URL = undefined;
+    mockResolveIndex.mockResolvedValue("openai-small");
+    mockUploadFile.mockResolvedValue({ url: "https://blob.test/doc.md" });
+    mockFind.mockResolvedValue(null);
+    mockCreate.mockResolvedValue({ documentId: 11, versionId: 21, jobId: "job-1" });
+    mockCreateVersion.mockResolvedValue({ documentId: 11, versionId: 22, jobId: "job-2" });
+});
+
+describe("createAgentKnowledgeSink — first sync", () => {
+    it("uploads the file and creates a document keyed on the connector source id", async () => {
+        const sink = await createAgentKnowledgeSink(context);
+        const result = await sink.store(knowledgeItem());
+
+        expect(result).toEqual({
+            sourceId: SOURCE_ID,
+            documentId: 11,
+            versionId: 21,
+            jobId: "job-1",
+            revised: false,
+        });
+
+        expect(mockCreate).toHaveBeenCalledWith(
+            expect.objectContaining({
+                companyId: 7n,
+                userId: "user_abc",
+                category: AGENT_KNOWLEDGE_CATEGORY,
+                creationKey: `connector:agent-knowledge:${SOURCE_ID}`,
+                mimeType: "text/markdown",
+                url: "https://blob.test/doc.md",
+                processingUrl: "https://blob.test/doc.md",
+                ocrEnabled: true,
+                ocrProcessed: false,
+            })
+        );
+        expect(mockCreateVersion).not.toHaveBeenCalled();
+    });
+
+    it("keeps provenance in the uploaded text so retrieved chunks stay attributable", async () => {
+        const sink = await createAgentKnowledgeSink(context);
+        await sink.store(knowledgeItem());
+
+        const uploaded = firstCallArg<UploadArg>(mockUploadFile);
+        const body = uploaded.data.toString("utf-8");
+
+        expect(body).toContain("Imported from Claude Code (global) — agent");
+        expect(body).toContain("`agents/code-reviewer.md`");
+        expect(body).toContain("You review code carefully.");
+        expect(uploaded.contentType).toBe("text/markdown");
+        // Flat filename, extension preserved so the ingestion router still
+        // routes it to the markdown adapter.
+        expect(uploaded.filename).toBe("claude-code-global-agents-code-reviewer.md");
+    });
+
+    it("records the content hash so the next sync can detect a change", async () => {
+        const sink = await createAgentKnowledgeSink(context);
+        await sink.store(knowledgeItem());
+
+        const params = firstCallArg<LifecycleArg>(mockCreate);
+        expect(params.ocrMetadata).toEqual(
+            expect.objectContaining({
+                connector: "agent-knowledge",
+                sourceId: SOURCE_ID,
+                contentHash: "a".repeat(64),
+                tool: "claude-code",
+                kind: "agent",
+                relativePath: "agents/code-reviewer.md",
+            })
+        );
+        expect(params.processing.embeddingIndexKey).toBe("openai-small");
+    });
+
+    it("resolves the embedding index once per sink, not once per file", async () => {
+        const sink = await createAgentKnowledgeSink(context);
+        await sink.store(knowledgeItem());
+        await sink.store(knowledgeItem({ sourceId: `${SOURCE_ID}-2` }));
+
+        expect(mockResolveIndex).toHaveBeenCalledTimes(1);
+    });
+
+    it("honours an explicit category and embedding index", async () => {
+        const sink = await createAgentKnowledgeSink({
+            ...context,
+            category: "Playbooks",
+            embeddingIndexKey: "custom-index",
+        });
+        await sink.store(knowledgeItem());
+
+        expect(mockResolveIndex).not.toHaveBeenCalled();
+        const params = firstCallArg<LifecycleArg & { category: string }>(mockCreate);
+        expect(params.category).toBe("Playbooks");
+        expect(params.processing.embeddingIndexKey).toBe("custom-index");
+    });
+});
+
+/**
+ * The database storage backend (the default when S3 is unconfigured) returns
+ * relative URLs. The ingestion worker runs in a different process and fetches
+ * the URL verbatim, so a relative one dies inside the worker with
+ * "Failed to parse URL from /api/files/12" long after the sync reported success.
+ */
+describe("createAgentKnowledgeSink — relative blob URLs", () => {
+    beforeEach(() => {
+        mockUploadFile.mockResolvedValue({ url: "/api/files/12" });
+    });
+
+    it("keeps the row relative but hands the worker an absolute URL", async () => {
+        const sink = await createAgentKnowledgeSink({
+            ...context,
+            requestUrl: "http://localhost:3001/api/connectors/agent-knowledge",
+        });
+        await sink.store(knowledgeItem());
+
+        const params = firstCallArg<{ url: string; processingUrl: string }>(mockCreate);
+        expect(params.url).toBe("/api/files/12");
+        expect(params.processingUrl).toBe("http://localhost:3001/api/files/12");
+    });
+
+    it("falls back to APP_PUBLIC_URL for callers with no request", async () => {
+        mockEnv.server.APP_PUBLIC_URL = "https://knowledge.example.com";
+
+        const sink = await createAgentKnowledgeSink(context);
+        await sink.store(knowledgeItem());
+
+        const params = firstCallArg<{ processingUrl: string }>(mockCreate);
+        expect(params.processingUrl).toBe("https://knowledge.example.com/api/files/12");
+    });
+
+    it("refuses to dispatch rather than queue a job that cannot fetch its file", async () => {
+        const sink = await createAgentKnowledgeSink(context);
+
+        await expect(sink.store(knowledgeItem())).rejects.toThrow(/APP_PUBLIC_URL/);
+        expect(mockCreate).not.toHaveBeenCalled();
+    });
+
+    it("passes an absolute blob URL through untouched", async () => {
+        mockUploadFile.mockResolvedValue({ url: "https://s3.test/doc.md" });
+
+        const sink = await createAgentKnowledgeSink(context);
+        await sink.store(knowledgeItem());
+
+        const params = firstCallArg<{ url: string; processingUrl: string }>(mockCreate);
+        expect(params.url).toBe("https://s3.test/doc.md");
+        expect(params.processingUrl).toBe("https://s3.test/doc.md");
+    });
+
+    it("absolutizes the version path too", async () => {
+        mockFind.mockResolvedValue({ id: 11, ocrMetadata: { contentHash: "b".repeat(64) } });
+
+        const sink = await createAgentKnowledgeSink({
+            ...context,
+            requestUrl: "http://localhost:3001/api/connectors/agent-knowledge",
+        });
+        await sink.store(knowledgeItem());
+
+        const params = firstCallArg<{ url: string; processingUrl: string }>(mockCreateVersion);
+        expect(params.url).toBe("/api/files/12");
+        expect(params.processingUrl).toBe("http://localhost:3001/api/files/12");
+    });
+});
+
+describe("createAgentKnowledgeSink — re-sync", () => {
+    it("adds a version to the existing document when the content changed", async () => {
+        mockFind.mockResolvedValue({ id: 11, ocrMetadata: { contentHash: "b".repeat(64) } });
+
+        const sink = await createAgentKnowledgeSink(context);
+        const result = await sink.store(knowledgeItem());
+
+        expect(mockCreate).not.toHaveBeenCalled();
+        expect(mockCreateVersion).toHaveBeenCalledWith(
+            expect.objectContaining({
+                documentId: 11,
+                companyId: 7n,
+                // The hash in the key makes a repeated call converge on the
+                // version it already created instead of stacking new ones.
+                creationKey: `connector:agent-knowledge:${SOURCE_ID}:v:${"a".repeat(64)}`,
+            })
+        );
+        expect(result.revised).toBe(true);
+        expect(result.versionId).toBe(22);
+    });
+
+    it("writes the new hash back to the document after a revision", async () => {
+        mockFind.mockResolvedValue({ id: 11, ocrMetadata: { contentHash: "b".repeat(64) } });
+
+        const sink = await createAgentKnowledgeSink(context);
+        await sink.store(knowledgeItem());
+
+        expect(mockDbUpdate).toHaveBeenCalledTimes(1);
+        const patch = firstCallArg<{ ocrMetadata: Record<string, unknown> }>(mockUpdateSet);
+        expect(patch.ocrMetadata.contentHash).toBe("a".repeat(64));
+        expect(patch.ocrMetadata.sourceId).toBe(SOURCE_ID);
+    });
+
+    it("reports the last synced hash from the stored document", async () => {
+        mockFind.mockResolvedValue({ id: 11, ocrMetadata: { contentHash: "c".repeat(64) } });
+
+        const sink = await createAgentKnowledgeSink(context);
+
+        expect(await sink.lastSyncedHash?.(knowledgeItem())).toBe("c".repeat(64));
+        expect(mockFind).toHaveBeenCalledWith(7n, `connector:agent-knowledge:${SOURCE_ID}`);
+    });
+
+    it("reports no hash for a source it has never seen, or one stored without metadata", async () => {
+        const sink = await createAgentKnowledgeSink(context);
+
+        mockFind.mockResolvedValue(null);
+        expect(await sink.lastSyncedHash?.(knowledgeItem())).toBeNull();
+
+        mockFind.mockResolvedValue({ id: 11, ocrMetadata: null });
+        expect(await sink.lastSyncedHash?.(knowledgeItem())).toBeNull();
+    });
+});

--- a/apps/web/__tests__/connectors/agent-knowledge-sync.test.ts
+++ b/apps/web/__tests__/connectors/agent-knowledge-sync.test.ts
@@ -1,0 +1,246 @@
+/**
+ * Sync orchestration against an in-memory sink: change detection, error
+ * containment and concurrency. No database, no blob storage — the point of the
+ * `KnowledgeSink` seam is that this layer is testable without either.
+ */
+
+import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { syncAgentKnowledge } from "@launchstack/features/connectors/agent-knowledge";
+import type {
+    DiscoveredKnowledgeItem,
+    KnowledgeItem,
+    KnowledgeSink,
+    StoredKnowledgeItem,
+} from "@launchstack/features/connectors";
+
+let root: string;
+let home: string;
+
+async function write(file: string, contents: string): Promise<void> {
+    await mkdir(path.dirname(file), { recursive: true });
+    await writeFile(file, contents, "utf8");
+}
+
+function claudeFile(name: string): string {
+    return path.join(home, ".claude", name);
+}
+
+interface RecordingSink extends KnowledgeSink {
+    readonly stored: KnowledgeItem[];
+    readonly hashes: Map<string, string>;
+    concurrentPeak: number;
+}
+
+function createRecordingSink(
+    overrides: { failOn?: (item: KnowledgeItem) => string | null; delayMs?: number } = {}
+): RecordingSink {
+    const stored: KnowledgeItem[] = [];
+    const hashes = new Map<string, string>();
+    let inFlight = 0;
+    let documentId = 0;
+
+    const sink: RecordingSink = {
+        stored,
+        hashes,
+        concurrentPeak: 0,
+        async lastSyncedHash(item: DiscoveredKnowledgeItem): Promise<string | null> {
+            return hashes.get(item.sourceId) ?? null;
+        },
+        async store(item: KnowledgeItem): Promise<StoredKnowledgeItem> {
+            inFlight += 1;
+            sink.concurrentPeak = Math.max(sink.concurrentPeak, inFlight);
+            try {
+                if (overrides.delayMs) {
+                    await new Promise(resolve => setTimeout(resolve, overrides.delayMs));
+                }
+                const failure = overrides.failOn?.(item);
+                if (failure) throw new Error(failure);
+
+                const revised = hashes.has(item.sourceId);
+                hashes.set(item.sourceId, item.contentHash);
+                stored.push(item);
+                documentId += 1;
+                return {
+                    sourceId: item.sourceId,
+                    documentId,
+                    versionId: documentId,
+                    jobId: `job-${documentId}`,
+                    revised,
+                };
+            } finally {
+                inFlight -= 1;
+            }
+        },
+    };
+
+    return sink;
+}
+
+beforeEach(async () => {
+    root = await mkdtemp(path.join(tmpdir(), "agent-knowledge-sync-"));
+    home = path.join(root, "home");
+    await mkdir(home, { recursive: true });
+});
+
+afterEach(async () => {
+    await rm(root, { recursive: true, force: true });
+});
+
+describe("syncAgentKnowledge", () => {
+    it("uploads everything it finds on a first run", async () => {
+        await write(claudeFile("CLAUDE.md"), "# Rules");
+        await write(claudeFile("agents/reviewer.md"), "You review.");
+
+        const sink = createRecordingSink();
+        const report = await syncAgentKnowledge({
+            homeDir: home,
+            tools: ["claude-code"],
+            sink,
+        });
+
+        expect(report.discovered).toBe(2);
+        expect(report.stored).toHaveLength(2);
+        expect(report.failed).toHaveLength(0);
+        expect(report.stored.every(entry => !entry.revised)).toBe(true);
+        expect(sink.stored.map(item => item.content)).toEqual(
+            expect.arrayContaining(["# Rules", "You review."])
+        );
+    });
+
+    it("skips files whose content has not changed since the last sync", async () => {
+        await write(claudeFile("CLAUDE.md"), "# Rules");
+        const sink = createRecordingSink();
+
+        await syncAgentKnowledge({ homeDir: home, tools: ["claude-code"], sink });
+        const second = await syncAgentKnowledge({ homeDir: home, tools: ["claude-code"], sink });
+
+        expect(second.stored).toHaveLength(0);
+        expect(second.skipped).toEqual([
+            expect.objectContaining({
+                sourceId: "agent-knowledge://claude-code/global/CLAUDE.md",
+                reason: "unchanged",
+            }),
+        ]);
+        expect(sink.stored).toHaveLength(1);
+    });
+
+    it("re-uploads a file once its content changes, marked as a revision", async () => {
+        await write(claudeFile("CLAUDE.md"), "# Rules");
+        const sink = createRecordingSink();
+
+        await syncAgentKnowledge({ homeDir: home, tools: ["claude-code"], sink });
+        await write(claudeFile("CLAUDE.md"), "# Rules, revised");
+        const second = await syncAgentKnowledge({ homeDir: home, tools: ["claude-code"], sink });
+
+        expect(second.stored).toEqual([expect.objectContaining({ revised: true })]);
+        expect(sink.stored.at(-1)?.content).toBe("# Rules, revised");
+    });
+
+    it("re-uploads unchanged content when forced", async () => {
+        await write(claudeFile("CLAUDE.md"), "# Rules");
+        const sink = createRecordingSink();
+
+        await syncAgentKnowledge({ homeDir: home, tools: ["claude-code"], sink });
+        const forced = await syncAgentKnowledge({
+            homeDir: home,
+            tools: ["claude-code"],
+            sink,
+            force: true,
+        });
+
+        expect(forced.stored).toHaveLength(1);
+        expect(forced.skipped.filter(entry => entry.reason === "unchanged")).toHaveLength(0);
+    });
+
+    it("keeps going when one file fails and reports it", async () => {
+        await write(claudeFile("CLAUDE.md"), "# Rules");
+        await write(claudeFile("agents/broken.md"), "boom");
+        await write(claudeFile("agents/fine.md"), "ok");
+
+        const sink = createRecordingSink({
+            failOn: item => (item.sourceId.endsWith("broken.md") ? "storage exploded" : null),
+        });
+
+        const report = await syncAgentKnowledge({ homeDir: home, tools: ["claude-code"], sink });
+
+        expect(report.stored).toHaveLength(2);
+        expect(report.failed).toEqual([
+            {
+                sourceId: "agent-knowledge://claude-code/global/agents/broken.md",
+                error: "storage exploded",
+            },
+        ]);
+    });
+
+    it("carries discovery skips through to the report", async () => {
+        await write(claudeFile("CLAUDE.md"), "# Rules");
+        await write(claudeFile("memory/auth.json"), "{}");
+        await write(claudeFile("agents/empty.md"), "");
+
+        const sink = createRecordingSink();
+        const report = await syncAgentKnowledge({ homeDir: home, tools: ["claude-code"], sink });
+
+        expect(report.stored).toHaveLength(1);
+        expect(report.skipped.map(entry => entry.reason)).toEqual(
+            expect.arrayContaining(["empty", "excluded"])
+        );
+    });
+
+    it("honours the concurrency ceiling", async () => {
+        for (const name of ["a", "b", "c", "d", "e", "f"]) {
+            await write(claudeFile(`agents/${name}.md`), name);
+        }
+
+        const sink = createRecordingSink({ delayMs: 5 });
+        await syncAgentKnowledge({
+            homeDir: home,
+            tools: ["claude-code"],
+            sink,
+            concurrency: 2,
+        });
+
+        expect(sink.stored).toHaveLength(6);
+        expect(sink.concurrentPeak).toBeLessThanOrEqual(2);
+    });
+
+    it("works against a sink with no change detection at all", async () => {
+        await write(claudeFile("CLAUDE.md"), "# Rules");
+        const calls: string[] = [];
+        const sink: KnowledgeSink = {
+            async store(item) {
+                calls.push(item.sourceId);
+                return {
+                    sourceId: item.sourceId,
+                    documentId: 1,
+                    versionId: 1,
+                    jobId: null,
+                    revised: false,
+                };
+            },
+        };
+
+        await syncAgentKnowledge({ homeDir: home, tools: ["claude-code"], sink });
+        await syncAgentKnowledge({ homeDir: home, tools: ["claude-code"], sink });
+
+        expect(calls).toHaveLength(2);
+    });
+
+    it("times the run from a caller-supplied clock", async () => {
+        await write(claudeFile("CLAUDE.md"), "# Rules");
+        const times = [new Date("2026-08-09T10:00:00Z"), new Date("2026-08-09T10:00:03Z")];
+
+        const report = await syncAgentKnowledge({
+            homeDir: home,
+            tools: ["claude-code"],
+            sink: createRecordingSink(),
+            now: () => times.shift() ?? new Date("2026-08-09T10:00:03Z"),
+        });
+
+        expect(report.startedAt).toBe("2026-08-09T10:00:00.000Z");
+        expect(report.durationMs).toBe(3000);
+        expect(report.connectorId).toBe("agent-knowledge");
+    });
+});

--- a/apps/web/src/app/api/connectors/agent-knowledge/route.ts
+++ b/apps/web/src/app/api/connectors/agent-knowledge/route.ts
@@ -1,0 +1,245 @@
+/**
+ * Agent-knowledge connector endpoint.
+ *
+ * GET  — preview what a sync would pick up (stats only, no file contents).
+ * POST — read it and push it through the normal ingestion pipeline.
+ *
+ * The connector reads this server's filesystem, so both verbs are gated on
+ * `AGENT_KNOWLEDGE_CONNECTOR_ENABLED` and on the caller owning the workspace.
+ */
+
+import { auth } from "@clerk/nextjs/server";
+import { eq } from "drizzle-orm";
+import type { NextResponse } from "next/server";
+import { z } from "zod";
+
+import { db } from "~/server/db";
+import { users } from "~/server/db/schema";
+import { env } from "~/env";
+import { resolveActiveCompanyForUser } from "~/lib/active-workspace";
+import { withRateLimit } from "~/lib/rate-limit-middleware";
+import { RateLimitPresets } from "~/lib/rate-limiter";
+import {
+    createForbiddenError,
+    createUnauthorizedError,
+    createValidationError,
+    createSuccessResponse,
+    handleApiError,
+} from "~/lib/api-utils";
+import {
+    previewAgentKnowledge,
+    runAgentKnowledgeSync,
+} from "~/server/services/agent-knowledge-connector";
+import {
+    configuredProjectRoots,
+    isAgentKnowledgeConnectorEnabled,
+    resolveProjectRoots,
+} from "~/server/services/agent-knowledge-policy";
+
+export const runtime = "nodejs";
+export const maxDuration = 300;
+
+const TOOLS = ["claude-code", "codex"] as const;
+const SCOPES = ["global", "project"] as const;
+
+const SyncRequestSchema = z.object({
+    tools: z.array(z.enum(TOOLS)).min(1).optional(),
+    scopes: z.array(z.enum(SCOPES)).min(1).optional(),
+    /** Project directories to scan. Must sit inside AGENT_KNOWLEDGE_PROJECT_ROOTS. */
+    projects: z.array(z.string().min(1)).optional(),
+    includeConfig: z.boolean().optional(),
+    force: z.boolean().optional(),
+    category: z.string().min(1).max(120).optional(),
+    concurrency: z.number().int().min(1).max(16).optional(),
+    maxItems: z.number().int().min(1).max(5000).optional(),
+});
+
+interface Caller {
+    readonly userId: string;
+    readonly companyId: bigint;
+}
+
+type CallerResult = { ok: true; caller: Caller } | { ok: false; response: NextResponse };
+
+async function resolveCaller(): Promise<CallerResult> {
+    const { userId } = await auth();
+    if (!userId) {
+        return { ok: false, response: createUnauthorizedError("Authentication required.") };
+    }
+
+    const [userInfo] = await db
+        .select({ id: users.id, role: users.role, companyId: users.companyId })
+        .from(users)
+        .where(eq(users.userId, userId));
+
+    if (!userInfo) {
+        return { ok: false, response: createValidationError("Invalid user.") };
+    }
+    // Imported knowledge lands in the shared company knowledge base, so this
+    // is a workspace-administration action, not a per-employee one.
+    if (userInfo.role !== "employer" && userInfo.role !== "owner") {
+        return { ok: false, response: createForbiddenError("Employer access required.") };
+    }
+
+    return {
+        ok: true,
+        caller: {
+            userId,
+            companyId: await resolveActiveCompanyForUser(userInfo.id, userInfo.companyId),
+        },
+    };
+}
+
+function disabledResponse(): NextResponse {
+    return createForbiddenError(
+        "The agent-knowledge connector is disabled. Set AGENT_KNOWLEDGE_CONNECTOR_ENABLED=true on the server that hosts your Claude Code / Codex folders."
+    );
+}
+
+/**
+ * "Sync everything with the defaults" is the common call, so an empty body is
+ * valid input rather than malformed JSON.
+ */
+async function parseSyncBody(
+    request: Request
+): Promise<z.SafeParseReturnType<unknown, z.infer<typeof SyncRequestSchema>> | null> {
+    const raw = await request.text();
+    if (raw.trim().length === 0) return SyncRequestSchema.safeParse({});
+    try {
+        return SyncRequestSchema.safeParse(JSON.parse(raw));
+    } catch {
+        return null;
+    }
+}
+
+function parseListParam(value: string | null): string[] | undefined {
+    if (!value) return undefined;
+    const parts = value
+        .split(",")
+        .map(part => part.trim())
+        .filter(part => part.length > 0);
+    return parts.length > 0 ? parts : undefined;
+}
+
+export async function GET(request: Request) {
+    return withRateLimit(request, RateLimitPresets.permissive, async () => {
+        try {
+            const enabled = isAgentKnowledgeConnectorEnabled(
+                env.server.AGENT_KNOWLEDGE_CONNECTOR_ENABLED
+            );
+            const callerResult = await resolveCaller();
+            if (!callerResult.ok) return callerResult.response;
+            if (!enabled) return disabledResponse();
+
+            const { searchParams } = new URL(request.url);
+            const roots = configuredProjectRoots(env.server.AGENT_KNOWLEDGE_PROJECT_ROOTS);
+            const decision = resolveProjectRoots(
+                parseListParam(searchParams.get("projects")),
+                roots
+            );
+
+            const scan = await previewAgentKnowledge({
+                tools: parseListParam(searchParams.get("tools")) as
+                    | (typeof TOOLS)[number][]
+                    | undefined,
+                scopes: parseListParam(searchParams.get("scopes")) as
+                    | (typeof SCOPES)[number][]
+                    | undefined,
+                projects: decision.allowed.map(dir => ({ dir })),
+                includeConfig: searchParams.get("includeConfig") === "true",
+            });
+
+            return createSuccessResponse({
+                enabled: true,
+                configuredProjectRoots: roots,
+                rejectedProjects: decision.rejected,
+                roots: scan.roots,
+                truncated: scan.truncated,
+                items: scan.items.map(item => ({
+                    sourceId: item.sourceId,
+                    title: item.title,
+                    kind: item.kind,
+                    bytes: item.bytes,
+                    modifiedAt: item.modifiedAt,
+                    relativePath: item.location.relativePath,
+                })),
+                skipped: scan.skipped,
+            });
+        } catch (error) {
+            return handleApiError(error);
+        }
+    });
+}
+
+export async function POST(request: Request) {
+    return withRateLimit(request, RateLimitPresets.strict, async () => {
+        try {
+            const enabled = isAgentKnowledgeConnectorEnabled(
+                env.server.AGENT_KNOWLEDGE_CONNECTOR_ENABLED
+            );
+            const callerResult = await resolveCaller();
+            if (!callerResult.ok) return callerResult.response;
+            if (!enabled) return disabledResponse();
+
+            const parsed = await parseSyncBody(request);
+            if (!parsed) return createValidationError("Invalid JSON body.");
+            if (!parsed.success) {
+                return createValidationError(
+                    `Invalid request data: ${parsed.error.errors
+                        .map(issue => `${issue.path.join(".")}: ${issue.message}`)
+                        .join(", ")}`
+                );
+            }
+
+            const body = parsed.data;
+            const roots = configuredProjectRoots(env.server.AGENT_KNOWLEDGE_PROJECT_ROOTS);
+            const decision = resolveProjectRoots(body.projects, roots);
+
+            if (decision.rejected.length > 0) {
+                return createForbiddenError(
+                    `Project directories outside AGENT_KNOWLEDGE_PROJECT_ROOTS: ${decision.rejected.join(", ")}`
+                );
+            }
+
+            const report = await runAgentKnowledgeSync({
+                companyId: callerResult.caller.companyId,
+                userId: callerResult.caller.userId,
+                tools: body.tools,
+                scopes: body.scopes,
+                projects: decision.allowed.map(dir => ({ dir })),
+                includeConfig: body.includeConfig,
+                maxItems: body.maxItems,
+                category: body.category,
+                concurrency: body.concurrency,
+                force: body.force,
+                requestUrl: request.url,
+            });
+
+            return createSuccessResponse(
+                {
+                    connectorId: report.connectorId,
+                    startedAt: report.startedAt,
+                    finishedAt: report.finishedAt,
+                    durationMs: report.durationMs,
+                    truncated: report.truncated,
+                    roots: report.scan.roots,
+                    counts: {
+                        discovered: report.discovered,
+                        stored: report.stored.length,
+                        created: report.stored.filter(entry => !entry.revised).length,
+                        revised: report.stored.filter(entry => entry.revised).length,
+                        skipped: report.skipped.length,
+                        failed: report.failed.length,
+                    },
+                    stored: report.stored,
+                    skipped: report.skipped,
+                    failed: report.failed,
+                },
+                `Synced ${report.stored.length} of ${report.discovered} knowledge files.`,
+                202
+            );
+        } catch (error) {
+            return handleApiError(error);
+        }
+    });
+}

--- a/apps/web/src/env.ts
+++ b/apps/web/src/env.ts
@@ -99,6 +99,16 @@ const serverSchema = z.object({
   JOB_RUNNER: z.enum(["inngest"]).default("inngest"),
   // Inngest event key — required in production; optional in development
   INNGEST_EVENT_KEY: optionalString(),
+  // Agent-knowledge connector. Reads Claude Code / Codex knowledge from the
+  // filesystem of the machine running this server, so it stays off unless a
+  // deployment explicitly opts in — on a shared host the server's disk is not
+  // the user's disk.
+  AGENT_KNOWLEDGE_CONNECTOR_ENABLED: optionalString(),
+  // Path-separator-delimited allowlist of project directories the connector
+  // may scan (`:` on POSIX, `;` on Windows). Global `~/.claude` and `~/.codex`
+  // are always in scope when the connector is enabled; this governs
+  // project-scoped roots only.
+  AGENT_KNOWLEDGE_PROJECT_ROOTS: optionalString(),
   // services/transcription (ADR-004) — Whisper transcription + yt-dlp
   // download. Used by the voice features when TRANSCRIPTION_PROVIDER=sidecar
   // or when transcribing video-platform URLs.
@@ -347,6 +357,8 @@ function parseServerEnv() {
     TRANSCRIPTION_SERVICE_API_KEY: process.env.TRANSCRIPTION_SERVICE_API_KEY,
     DOCUMENT_EDITOR_URL: process.env.DOCUMENT_EDITOR_URL,
     DOCUMENT_EDITOR_API_KEY: process.env.DOCUMENT_EDITOR_API_KEY,
+    AGENT_KNOWLEDGE_CONNECTOR_ENABLED: process.env.AGENT_KNOWLEDGE_CONNECTOR_ENABLED,
+    AGENT_KNOWLEDGE_PROJECT_ROOTS: process.env.AGENT_KNOWLEDGE_PROJECT_ROOTS,
     SIDECAR_URL: process.env.SIDECAR_URL,
     SIDECAR_API_KEY: process.env.SIDECAR_API_KEY,
     ADEU_SERVICE_URL: process.env.ADEU_SERVICE_URL,

--- a/apps/web/src/lib/api-utils.ts
+++ b/apps/web/src/lib/api-utils.ts
@@ -26,7 +26,9 @@ export interface ErrorResponse {
 export function createSuccessResponse<T>(
   data?: T,
   message?: string,
-  status = HTTP_STATUS.OK
+  // Annotated rather than inferred: `HTTP_STATUS` is `as const`, so an
+  // inferred default would pin every caller to exactly 200.
+  status: number = HTTP_STATUS.OK
 ): NextResponse<SuccessResponse<T>> {
   return NextResponse.json(
     {

--- a/apps/web/src/lib/constants.ts
+++ b/apps/web/src/lib/constants.ts
@@ -98,6 +98,7 @@ export type ErrorType = typeof ERROR_TYPES[keyof typeof ERROR_TYPES];
 export const HTTP_STATUS = {
   OK: 200,
   CREATED: 201,
+  ACCEPTED: 202,
   BAD_REQUEST: 400,
   UNAUTHORIZED: 401,
   FORBIDDEN: 403,

--- a/apps/web/src/lib/rate-limiter.ts
+++ b/apps/web/src/lib/rate-limiter.ts
@@ -79,6 +79,10 @@ class RateLimitStore {
     this.cleanupInterval = setInterval(() => {
       this.cleanup();
     }, 5 * 60 * 1000);
+    // Housekeeping only — it must never be the reason a process stays alive.
+    // Without this, merely importing a rate-limited route hangs a Jest worker
+    // (and any short-lived script) until the runner is force-exited.
+    this.cleanupInterval.unref?.();
   }
 
   /**

--- a/apps/web/src/server/services/agent-knowledge-connector.ts
+++ b/apps/web/src/server/services/agent-knowledge-connector.ts
@@ -1,0 +1,303 @@
+/**
+ * Host wiring for the agent-knowledge connector.
+ *
+ * The connector (`@launchstack/features/connectors/agent-knowledge`) finds and
+ * reads Claude Code / Codex knowledge; this module is the `KnowledgeSink` that
+ * puts it in the knowledge base: blob upload → document lifecycle → the same
+ * OCR/embedding pipeline every other upload goes through.
+ */
+
+import { eq } from "drizzle-orm";
+
+import {
+    syncAgentKnowledge,
+    scanAgentKnowledge,
+    type AgentKnowledgeScan,
+    type AgentKnowledgeScanOptions,
+    type AgentKnowledgeSyncResult,
+} from "@launchstack/features/connectors/agent-knowledge";
+import type {
+    DiscoveredKnowledgeItem,
+    KnowledgeItem,
+    KnowledgeSink,
+    StoredKnowledgeItem,
+} from "@launchstack/features/connectors";
+import { document } from "@launchstack/core/db/schema";
+import { resolveIngestIndexKey } from "@launchstack/core/embeddings";
+
+import { db } from "~/server/db";
+import { env } from "~/env";
+import { uploadFile } from "~/lib/storage";
+import { getEngine } from "~/server/engine";
+import { toAbsoluteUrl } from "./detect-storage-type";
+import {
+    createDocumentLifecycle,
+    createDocumentVersionLifecycle,
+    findDocumentByCreationKey,
+} from "./document-creation";
+
+export const AGENT_KNOWLEDGE_CATEGORY = "Agent Knowledge";
+
+/** Namespace for the document creation key. Keep stable — it is an identity. */
+const CREATION_KEY_PREFIX = "connector:agent-knowledge:";
+
+export interface AgentKnowledgeSinkContext {
+    readonly companyId: bigint;
+    readonly userId: string;
+    readonly category?: string;
+    readonly embeddingIndexKey?: string;
+    /**
+     * Origin used to absolutize a relative blob URL. Pass `request.url` from a
+     * route; falls back to `APP_PUBLIC_URL` for script and cron callers.
+     */
+    readonly requestUrl?: string;
+}
+
+interface StoredMetadata {
+    readonly connector: string;
+    readonly sourceId: string;
+    readonly contentHash: string;
+    readonly tool: unknown;
+    readonly scope: unknown;
+    readonly scopeKey: unknown;
+    readonly kind: string;
+    readonly relativePath: string;
+    readonly modifiedAt: string;
+    readonly syncedAt: string;
+}
+
+function creationKeyFor(item: DiscoveredKnowledgeItem): string {
+    return `${CREATION_KEY_PREFIX}${item.sourceId}`;
+}
+
+/**
+ * Connector metadata is `Record<string, unknown>` by contract — one connector's
+ * keys are not another's — so every read out of it is narrowed here rather than
+ * cast at the use site.
+ */
+function metaString(item: KnowledgeItem, key: string, fallback: string): string {
+    const value = item.metadata[key];
+    return typeof value === "string" && value.length > 0 ? value : fallback;
+}
+
+/**
+ * Blob-storage filenames must stay flat, so the source's directory structure
+ * is folded into the name. The extension is preserved because the ingestion
+ * router picks its adapter from it.
+ */
+function blobFilenameFor(item: KnowledgeItem): string {
+    const flattened = item.location.relativePath.replace(/[^a-zA-Z0-9._-]+/g, "-");
+    const tool = metaString(item, "tool", "agent");
+    const scopeKey = metaString(item, "scopeKey", "global");
+    return `${tool}-${scopeKey}-${flattened}`;
+}
+
+/**
+ * Retrieval sees chunks, not documents, so the provenance has to live in the
+ * text itself — otherwise a chunk of a subagent definition is indistinguishable
+ * from a chunk of a hand-written note.
+ */
+function withProvenanceHeader(item: KnowledgeItem, syncedAt: string): string {
+    const toolLabel = metaString(item, "toolLabel", metaString(item, "tool", "agent"));
+    const scopeKey = metaString(item, "scopeKey", "global");
+    return [
+        `> Imported from ${toolLabel} (${scopeKey}) — ${item.kind}: \`${item.location.relativePath}\`.`,
+        `> Source last modified ${item.modifiedAt}; synced ${syncedAt}.`,
+        "",
+        item.content,
+        "",
+    ].join("\n");
+}
+
+/**
+ * The database storage backend returns relative URLs (`/api/files/12`). The
+ * document row keeps that relative form — the UI resolves it per request — but
+ * the ingestion worker runs in a different process and fetches the URL as
+ * given, so what goes into the job must be absolute.
+ *
+ * Failing loudly here beats dispatching a job that dies later inside the worker
+ * with `Failed to parse URL from /api/files/12`.
+ */
+function toProcessingUrl(blobUrl: string, requestUrl: string | undefined): string {
+    if (blobUrl.startsWith("http://") || blobUrl.startsWith("https://")) return blobUrl;
+
+    const base = requestUrl ?? env.server.APP_PUBLIC_URL;
+    if (!base) {
+        throw new Error(
+            `Cannot dispatch ingestion for a relative document URL (${blobUrl}). ` +
+                "The database storage backend is in use, so the ingestion worker needs an " +
+                "absolute URL — set APP_PUBLIC_URL, or pass requestUrl to the sink."
+        );
+    }
+    return toAbsoluteUrl(blobUrl, base);
+}
+
+function readContentHash(ocrMetadata: unknown): string | null {
+    if (typeof ocrMetadata !== "object" || ocrMetadata === null) return null;
+    const hash = (ocrMetadata as Record<string, unknown>).contentHash;
+    return typeof hash === "string" ? hash : null;
+}
+
+/**
+ * Build the sink. `resolveIngestIndexKey` is read once per sink rather than
+ * per item: re-resolving mid-sync would let a concurrent reindex split one
+ * batch of documents across two embedding indexes.
+ */
+export async function createAgentKnowledgeSink(
+    context: AgentKnowledgeSinkContext
+): Promise<KnowledgeSink> {
+    // Populates the storage / job-dispatcher / provider slots the lifecycle
+    // dispatch below depends on. Idempotent and cached.
+    getEngine();
+
+    const embeddingIndexKey =
+        context.embeddingIndexKey ??
+        (await resolveIngestIndexKey(context.companyId)) ??
+        undefined;
+    const category = context.category ?? AGENT_KNOWLEDGE_CATEGORY;
+
+    return {
+        async lastSyncedHash(item: DiscoveredKnowledgeItem): Promise<string | null> {
+            const existing = await findDocumentByCreationKey(
+                context.companyId,
+                creationKeyFor(item)
+            );
+            return existing ? readContentHash(existing.ocrMetadata) : null;
+        },
+
+        async store(item: KnowledgeItem): Promise<StoredKnowledgeItem> {
+            const syncedAt = new Date().toISOString();
+            const baseCreationKey = creationKeyFor(item);
+            const body = withProvenanceHeader(item, syncedAt);
+            const filename = blobFilenameFor(item);
+
+            const metadata: StoredMetadata = {
+                connector: item.connectorId,
+                sourceId: item.sourceId,
+                contentHash: item.contentHash,
+                tool: item.metadata.tool,
+                scope: item.metadata.scope,
+                scopeKey: item.metadata.scopeKey,
+                kind: item.kind,
+                relativePath: item.location.relativePath,
+                modifiedAt: item.modifiedAt,
+                syncedAt,
+            };
+
+            const existing = await findDocumentByCreationKey(context.companyId, baseCreationKey);
+
+            const blob = await uploadFile({
+                filename,
+                data: Buffer.from(body, "utf-8"),
+                contentType: item.mimeType,
+                userId: context.userId,
+            });
+            const processingUrl = toProcessingUrl(blob.url, context.requestUrl);
+
+            if (!existing) {
+                const lifecycle = await createDocumentLifecycle({
+                    companyId: context.companyId,
+                    userId: context.userId,
+                    title: item.title,
+                    category,
+                    url: blob.url,
+                    processingUrl,
+                    creationKey: baseCreationKey,
+                    mimeType: item.mimeType,
+                    ocrEnabled: true,
+                    ocrProcessed: false,
+                    ocrMetadata: { ...metadata },
+                    processing: {
+                        originalFilename: filename,
+                        embeddingIndexKey,
+                    },
+                });
+
+                return {
+                    sourceId: item.sourceId,
+                    documentId: lifecycle.documentId,
+                    versionId: lifecycle.versionId,
+                    jobId: lifecycle.jobId,
+                    revised: false,
+                };
+            }
+
+            const lifecycle = await createDocumentVersionLifecycle({
+                documentId: existing.id,
+                companyId: context.companyId,
+                userId: context.userId,
+                title: item.title,
+                category,
+                url: blob.url,
+                processingUrl,
+                // The hash is part of the key so a re-sync of the *same* revised
+                // content converges on the version it already created instead of
+                // stacking a new one on every call.
+                creationKey: `${baseCreationKey}:v:${item.contentHash}`,
+                mimeType: item.mimeType,
+                fileSize: Buffer.byteLength(body, "utf-8"),
+                changelog: `Re-synced from ${metaString(item, "toolLabel", "agent")} on ${syncedAt}`,
+                originalFilename: filename,
+                embeddingIndexKey,
+            });
+
+            // The version lifecycle does not touch document-level metadata, so
+            // the hash that drives change detection is written here.
+            await db
+                .update(document)
+                .set({ ocrMetadata: { ...metadata } })
+                .where(eq(document.id, existing.id));
+
+            return {
+                sourceId: item.sourceId,
+                documentId: lifecycle.documentId,
+                versionId: lifecycle.versionId,
+                jobId: lifecycle.jobId,
+                revised: true,
+            };
+        },
+    };
+}
+
+export interface AgentKnowledgeSyncRequest extends AgentKnowledgeScanOptions {
+    readonly companyId: bigint;
+    readonly userId: string;
+    readonly category?: string;
+    readonly embeddingIndexKey?: string;
+    readonly concurrency?: number;
+    readonly force?: boolean;
+    readonly requestUrl?: string;
+}
+
+/** Scan the local agent folders and ingest everything that changed. */
+export async function runAgentKnowledgeSync(
+    request: AgentKnowledgeSyncRequest
+): Promise<AgentKnowledgeSyncResult> {
+    const {
+        companyId,
+        userId,
+        category,
+        embeddingIndexKey,
+        concurrency,
+        force,
+        requestUrl,
+        ...scanOptions
+    } = request;
+
+    const sink = await createAgentKnowledgeSink({
+        companyId,
+        userId,
+        category,
+        embeddingIndexKey,
+        requestUrl,
+    });
+
+    return syncAgentKnowledge({ ...scanOptions, sink, concurrency, force });
+}
+
+/** Preview what a sync would pick up, without reading or uploading anything. */
+export async function previewAgentKnowledge(
+    options: AgentKnowledgeScanOptions
+): Promise<AgentKnowledgeScan> {
+    return scanAgentKnowledge(options);
+}

--- a/apps/web/src/server/services/agent-knowledge-policy.ts
+++ b/apps/web/src/server/services/agent-knowledge-policy.ts
@@ -1,0 +1,84 @@
+/**
+ * Access policy for the agent-knowledge connector.
+ *
+ * The connector reads the filesystem of whatever machine runs this server. On
+ * a developer laptop or a self-hosted box that is the point; on a shared host
+ * it would be an arbitrary-read primitive pointed at someone else's disk. So
+ * the route is off unless a deployment opts in, and the set of project
+ * directories it may scan is fixed by configuration rather than by the
+ * request body.
+ */
+
+import path from "node:path";
+
+export interface ProjectRootDecision {
+    /** Directories that passed the allowlist, in request order. */
+    readonly allowed: string[];
+    /** Requested directories outside every configured root. */
+    readonly rejected: string[];
+}
+
+function isTruthy(value: string | undefined): boolean {
+    if (!value) return false;
+    const normalized = value.trim().toLowerCase();
+    return normalized === "1" || normalized === "true" || normalized === "yes" || normalized === "on";
+}
+
+export function isAgentKnowledgeConnectorEnabled(
+    flag: string | undefined = process.env.AGENT_KNOWLEDGE_CONNECTOR_ENABLED
+): boolean {
+    return isTruthy(flag);
+}
+
+/**
+ * Configured project roots, absolute and de-duplicated. Splitting on
+ * `path.delimiter` (not `,`) keeps Windows drive letters intact.
+ */
+export function configuredProjectRoots(
+    raw: string | undefined = process.env.AGENT_KNOWLEDGE_PROJECT_ROOTS
+): string[] {
+    if (!raw) return [];
+    const seen = new Set<string>();
+    for (const part of raw.split(path.delimiter)) {
+        const trimmed = part.trim();
+        if (trimmed.length === 0) continue;
+        seen.add(path.resolve(trimmed));
+    }
+    return [...seen];
+}
+
+/** True when `candidate` is `root` or sits underneath it. */
+export function isWithinRoot(root: string, candidate: string): boolean {
+    const relative = path.relative(root, candidate);
+    return relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative));
+}
+
+/**
+ * Resolve the project directories a request may scan.
+ *
+ * With no explicit request the caller gets every configured root — the common
+ * "sync everything" case. An explicit list is filtered against those roots;
+ * `..` cannot be used to climb out because both sides are resolved first.
+ */
+export function resolveProjectRoots(
+    requested: readonly string[] | undefined,
+    roots: readonly string[] = configuredProjectRoots()
+): ProjectRootDecision {
+    if (!requested || requested.length === 0) {
+        return { allowed: [...roots], rejected: [] };
+    }
+
+    const allowed: string[] = [];
+    const rejected: string[] = [];
+
+    for (const entry of requested) {
+        const resolved = path.resolve(entry);
+        if (roots.some(root => isWithinRoot(root, resolved))) {
+            if (!allowed.includes(resolved)) allowed.push(resolved);
+        } else if (!rejected.includes(resolved)) {
+            rejected.push(resolved);
+        }
+    }
+
+    return { allowed, rejected };
+}

--- a/apps/web/src/server/services/document-creation.ts
+++ b/apps/web/src/server/services/document-creation.ts
@@ -11,6 +11,7 @@
 export {
     createDocumentLifecycle,
     createDocumentVersionLifecycle,
+    findDocumentByCreationKey,
     type CreateDocumentLifecycleParams,
     type CreateDocumentVersionLifecycleParams,
     type CreatedDocumentLifecycle,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,9 +38,18 @@ x-shared-env: &shared-env
   AI_BASE_URL: ${AI_BASE_URL:-}
   AI_API_KEY: ${AI_API_KEY:-}
   OPENAI_API_KEY: ${OPENAI_API_KEY:-}
+  # Base URL and key are read as a PAIR at every level, so forwarding a model
+  # or a lone key is not enough — without its base URL a capability falls
+  # through to "API key not configured" at call time.
   EMBEDDING_MODEL: ${EMBEDDING_MODEL:-}
+  EMBEDDING_API_BASE_URL: ${EMBEDDING_API_BASE_URL:-}
+  EMBEDDING_API_KEY: ${EMBEDDING_API_KEY:-}
   RERANK_MODEL: ${RERANK_MODEL:-}
+  RERANK_API_BASE_URL: ${RERANK_API_BASE_URL:-}
+  RERANK_API_KEY: ${RERANK_API_KEY:-}
   NER_MODEL: ${NER_MODEL:-}
+  NER_API_BASE_URL: ${NER_API_BASE_URL:-}
+  NER_API_KEY: ${NER_API_KEY:-}
   TRANSCRIPTION_MODEL: ${TRANSCRIPTION_MODEL:-}
   TRANSCRIPTION_API_BASE_URL: ${TRANSCRIPTION_API_BASE_URL:-}
   TRANSCRIPTION_API_KEY: ${TRANSCRIPTION_API_KEY:-}

--- a/packages/adapters/src/index.ts
+++ b/packages/adapters/src/index.ts
@@ -13,6 +13,7 @@ export {
 export {
   createDocumentLifecycle,
   createDocumentVersionLifecycle,
+  findDocumentByCreationKey,
   type CreateDocumentLifecycleParams,
   type CreateDocumentVersionLifecycleParams,
   type CreatedDocumentLifecycle,

--- a/packages/adapters/src/ingestion/source-lifecycle.ts
+++ b/packages/adapters/src/ingestion/source-lifecycle.ts
@@ -50,6 +50,31 @@ function hashCreationKey(rawCreationKey: string): string {
         .digest("hex");
 }
 
+/**
+ * Resolve the document a creation key has already produced, if any.
+ *
+ * Callers that re-import the same logical source repeatedly (connectors) need
+ * to tell "never seen", "unchanged" and "changed" apart *before* uploading a
+ * payload to blob storage. Exposing this lookup keeps the key-hashing scheme
+ * private to this module.
+ */
+export async function findDocumentByCreationKey(
+    companyId: bigint,
+    rawCreationKey: string
+): Promise<Document | null> {
+    const [row] = await getDb()
+        .select()
+        .from(document)
+        .where(
+            and(
+                eq(document.companyId, companyId),
+                eq(document.creationKey, hashCreationKey(rawCreationKey))
+            )
+        )
+        .limit(1);
+    return row ?? null;
+}
+
 export interface DocumentCreationProcessing {
     preferredProvider?: string;
     originalFilename?: string;
@@ -129,6 +154,14 @@ export interface CreateDocumentVersionLifecycleParams {
     title: string;
     category: string;
     url: string;
+    /**
+     * URL handed to the extraction stage, when it differs from the one stored
+     * on the row. The database storage backend yields relative URLs that the
+     * UI resolves per request but a worker in another process cannot fetch.
+     * Mirrors `processingUrl` on {@link CreateDocumentLifecycleParams};
+     * defaults to `url`.
+     */
+    processingUrl?: string;
     creationKey: string;
     mimeType: string;
     fileSize?: number | bigint | null;
@@ -735,7 +768,7 @@ export async function createDocumentVersionLifecycle(
                             companyId: params.companyId,
                             userId: params.userId,
                             status: "queued",
-                            documentUrl: params.url,
+                            documentUrl: params.processingUrl ?? params.url,
                             documentName: params.title,
                             dispatchOptions: versionDispatchOptions,
                         })

--- a/packages/features/package.json
+++ b/packages/features/package.json
@@ -21,6 +21,14 @@
       "types": "./src/adeu/index.ts",
       "default": "./src/adeu/index.ts"
     },
+    "./connectors": {
+      "types": "./src/connectors/index.ts",
+      "default": "./src/connectors/index.ts"
+    },
+    "./connectors/agent-knowledge": {
+      "types": "./src/connectors/agent-knowledge/index.ts",
+      "default": "./src/connectors/agent-knowledge/index.ts"
+    },
     "./legal-templates": {
       "types": "./src/legal-templates/index.ts",
       "default": "./src/legal-templates/index.ts"

--- a/packages/features/src/connectors/README.md
+++ b/packages/features/src/connectors/README.md
@@ -1,8 +1,78 @@
 # @launchstack/features/connectors
 
-Stub — third-party data connectors (Nango-backed) will live here.
+Data connectors that register external bodies of knowledge as ingestion
+sources.
 
-Intent: a small set of first-class integrations (Google Drive, SharePoint,
-Notion, Slack, …) that register as ingestion sources. Authentication goes
-through Nango; the connector owns the polling / webhook → StoragePort +
-JobDispatcherPort plumbing so ingestion is unified.
+Every connector produces a flat list of `KnowledgeItem`s and hands them to a
+host-supplied `KnowledgeSink` (`types.ts`). Connectors never touch the database
+or blob storage directly — that keeps this package free of `apps/web` imports
+and makes each connector testable against an in-memory sink.
+
+## agent-knowledge — Claude Code & Codex
+
+`agent-knowledge/` reads the knowledge those two coding agents already keep on
+disk and uploads it. There is no OAuth handshake and no polling loop: the
+source is the local filesystem, so a sync is immediate.
+
+What it picks up:
+
+| Tool | Global (`~`) | Per project |
+| --- | --- | --- |
+| Claude Code | `.claude/CLAUDE.md`, `.claude/MEMORY.md`, `agents/`, `commands/`, `skills/`, `memory/`, `output-styles/`, `projects/<slug>/memory/` | `CLAUDE.md`, `CLAUDE.local.md`, `.claude/{agents,commands,skills,memory,output-styles}` |
+| Codex | `.codex/AGENTS.md`, `.codex/instructions.md`, `prompts/`, `memories/` | `AGENTS.md`, `.codex/{AGENTS.md,prompts,memories}` |
+
+`projects/<slug>/memory/` is the one place the connector reaches into
+`~/.claude/projects/`, which otherwise holds session transcripts. It is a
+`nested` layout entry — one fixed subdirectory of each slug, never a recursive
+walk — so the `.jsonl` transcripts sitting beside it stay out of reach.
+
+```ts
+import { syncAgentKnowledge } from "@launchstack/features/connectors/agent-knowledge";
+
+const report = await syncAgentKnowledge({
+    projects: [{ dir: "/srv/checkouts/launchstack" }],
+    sink: myKnowledgeSink,
+});
+```
+
+`scanAgentKnowledge()` is the cheap half — it stats files without opening them,
+so a UI can preview exactly what a sync would upload.
+
+### What it deliberately does not read
+
+Both tools mix authored knowledge with machine state under the same roots, so
+discovery is **allowlist-driven**: a path that is not named in `layout.ts`
+cannot be picked up. On top of that:
+
+- Credential files (`.credentials.json`, `auth.json`, `.env*`, `*.pem`,
+  `*.key`, anything matching `secret`/`token`/`credential`) are denylisted by
+  name, whatever their extension.
+- Config files (`settings.json`, `config.toml`) hold API keys, so they are
+  behind `includeConfig` and off by default.
+- Session transcripts, caches, sqlite journals, `sessions/`, `history.jsonl`
+  and friends are never walked — including everything under `projects/` except
+  the `memory/` subdirectory described above.
+- `~/.claude/plugins/` is skipped. Marketplace plugins are third-party
+  published content and a multi-megabyte checkout, not the user's own
+  knowledge.
+- Symlinks are never followed, and the walk cannot leave the root it started
+  in.
+- Files over 512 KiB, empty files, and files containing NUL bytes are skipped
+  with a reason rather than uploaded.
+
+Everything declined shows up in the report's `skipped` array with its reason —
+a sync never silently under-reports.
+
+### Change detection
+
+`sourceId` (`agent-knowledge://<tool>/<scope>/<relative-path>`) is the stable
+identity of an item across syncs and carries no absolute paths, so it survives
+a home directory move. The sink's optional `lastSyncedHash()` lets a re-sync
+skip files whose sha256 has not changed; hosts that do not implement it just
+re-upload every time, which is slower but always correct.
+
+## Future connectors
+
+Third-party sources (Google Drive, SharePoint, Notion, Slack) will authenticate
+through Nango and implement the same `KnowledgeSink` contract, so the ingestion
+path stays unified.

--- a/packages/features/src/connectors/agent-knowledge/collect.ts
+++ b/packages/features/src/connectors/agent-knowledge/collect.ts
@@ -1,0 +1,70 @@
+/**
+ * Reading half of the connector: turns discovered files into
+ * `KnowledgeItem`s with contents and a content hash.
+ */
+
+import { createHash } from "node:crypto";
+import { readFile } from "node:fs/promises";
+
+import type { DiscoveredKnowledgeItem, KnowledgeItem, SkippedKnowledgeItem } from "../types";
+import { describeError } from "./discover";
+
+export interface CollectedAgentKnowledge {
+    readonly items: readonly KnowledgeItem[];
+    readonly skipped: readonly SkippedKnowledgeItem[];
+}
+
+export function hashContent(content: string): string {
+    return createHash("sha256").update(content, "utf8").digest("hex");
+}
+
+/**
+ * A NUL byte means the file is a binary that happens to sit under an
+ * allowlisted path with a text extension — not knowledge. `readFile` with
+ * `utf8` would hand back mojibake rather than fail, so check explicitly.
+ */
+function looksBinary(content: string): boolean {
+    return content.includes("\u0000");
+}
+
+export async function readKnowledgeItem(
+    item: DiscoveredKnowledgeItem
+): Promise<KnowledgeItem | SkippedKnowledgeItem> {
+    let raw: string;
+    try {
+        raw = await readFile(item.location.origin, "utf8");
+    } catch (error) {
+        return { sourceId: item.sourceId, reason: "unreadable", detail: describeError(error) };
+    }
+
+    if (looksBinary(raw)) {
+        return { sourceId: item.sourceId, reason: "excluded", detail: "binary content" };
+    }
+
+    const content = raw.replace(/\r\n/g, "\n").trim();
+    if (content.length === 0) {
+        return { sourceId: item.sourceId, reason: "empty" };
+    }
+
+    return { ...item, content, contentHash: hashContent(content) };
+}
+
+function isSkipped(value: KnowledgeItem | SkippedKnowledgeItem): value is SkippedKnowledgeItem {
+    return "reason" in value;
+}
+
+/** Read every discovered item, keeping failures as skips rather than throwing. */
+export async function collectAgentKnowledge(
+    discovered: readonly DiscoveredKnowledgeItem[]
+): Promise<CollectedAgentKnowledge> {
+    const items: KnowledgeItem[] = [];
+    const skipped: SkippedKnowledgeItem[] = [];
+
+    for (const candidate of discovered) {
+        const result = await readKnowledgeItem(candidate);
+        if (isSkipped(result)) skipped.push(result);
+        else items.push(result);
+    }
+
+    return { items, skipped };
+}

--- a/packages/features/src/connectors/agent-knowledge/discover.ts
+++ b/packages/features/src/connectors/agent-knowledge/discover.ts
@@ -1,0 +1,437 @@
+/**
+ * Filesystem discovery for the agent-knowledge connector.
+ *
+ * Walks only the locations named in `layout.ts`, never follows symlinks, and
+ * refuses to leave the root it was pointed at. Everything it declines to read
+ * comes back as a `SkippedKnowledgeItem` so the caller can show the user what
+ * was left behind instead of silently under-reporting.
+ */
+
+import { lstat, readdir, realpath } from "node:fs/promises";
+import { homedir } from "node:os";
+import path from "node:path";
+
+import type { DiscoveredKnowledgeItem, SkippedKnowledgeItem } from "../types";
+import {
+    CONFIG_EXTENSIONS,
+    KNOWLEDGE_EXTENSIONS,
+    TOOL_LAYOUTS,
+    isDeniedDirectory,
+    isDeniedFilename,
+    layoutFor,
+    type AgentToolId,
+    type KnowledgeKind,
+    type KnowledgeScope,
+    type LayoutEntry,
+    type ToolLayout,
+} from "./layout";
+
+export const AGENT_KNOWLEDGE_CONNECTOR_ID = "agent-knowledge";
+
+/** 512 KiB — a knowledge file above this is a transcript, not instructions. */
+export const DEFAULT_MAX_FILE_BYTES = 512 * 1024;
+export const DEFAULT_MAX_ITEMS = 500;
+
+export interface ProjectTarget {
+    /** Directory to scan for project-scoped agent knowledge. */
+    readonly dir: string;
+    /**
+     * Stable identity for the project inside `sourceId`. Defaults to the
+     * directory's basename. Pass an explicit key when two checkouts share a
+     * basename, or when the same project may live at different paths.
+     */
+    readonly key?: string;
+}
+
+export interface AgentKnowledgeScanOptions {
+    /** Defaults to `os.homedir()`. */
+    readonly homeDir?: string;
+    /** Project directories to scan. Empty means "global knowledge only". */
+    readonly projects?: readonly (ProjectTarget | string)[];
+    /** Defaults to every known tool. */
+    readonly tools?: readonly AgentToolId[];
+    /** Defaults to both scopes (project scope needs `projects`). */
+    readonly scopes?: readonly KnowledgeScope[];
+    /** Read `settings.json` / `config.toml`. Off by default — they hold keys. */
+    readonly includeConfig?: boolean;
+    readonly maxFileBytes?: number;
+    readonly maxItems?: number;
+}
+
+export interface ScannedRoot {
+    readonly toolId: AgentToolId;
+    readonly scope: KnowledgeScope;
+    readonly key: string;
+    readonly dir: string;
+    readonly exists: boolean;
+    readonly itemCount: number;
+}
+
+export interface AgentKnowledgeScan {
+    readonly roots: readonly ScannedRoot[];
+    readonly items: readonly DiscoveredKnowledgeItem[];
+    readonly skipped: readonly SkippedKnowledgeItem[];
+    /** True when `maxItems` cut the walk short. */
+    readonly truncated: boolean;
+}
+
+const MIME_BY_EXTENSION: Readonly<Record<string, string>> = {
+    ".md": "text/markdown",
+    ".markdown": "text/markdown",
+    ".mdx": "text/markdown",
+    ".txt": "text/plain",
+    ".json": "application/json",
+    ".toml": "text/x-toml",
+    ".yaml": "text/x-yaml",
+    ".yml": "text/x-yaml",
+};
+
+function mimeTypeFor(filePath: string): string {
+    return MIME_BY_EXTENSION[path.extname(filePath).toLowerCase()] ?? "text/plain";
+}
+
+function normalizeProject(target: ProjectTarget | string): ProjectTarget {
+    return typeof target === "string" ? { dir: target } : target;
+}
+
+function projectKeyFor(target: ProjectTarget): string {
+    const explicit = target.key?.trim();
+    if (explicit) return explicit;
+    const base = path.basename(path.resolve(target.dir));
+    return base.length > 0 ? base : "project";
+}
+
+/**
+ * `agent-knowledge://<tool>/<scope-key>/<relative-path>`.
+ *
+ * Deliberately free of absolute paths: this string is the identity the host
+ * keys its documents on, and it has to survive the home directory moving.
+ */
+export function buildSourceId(
+    toolId: AgentToolId,
+    scopeKey: string,
+    relativePath: string
+): string {
+    const normalized = relativePath.split(path.sep).join("/");
+    return `${AGENT_KNOWLEDGE_CONNECTOR_ID}://${toolId}/${scopeKey}/${normalized}`;
+}
+
+function titleFor(layout: ToolLayout, scopeKey: string, relativePath: string): string {
+    const normalized = relativePath.split(path.sep).join("/");
+    return `${layout.label} (${scopeKey}) — ${normalized}`;
+}
+
+function isReadableExtension(name: string, includeConfig: boolean): boolean {
+    const ext = path.extname(name).toLowerCase();
+    if (KNOWLEDGE_EXTENSIONS.has(ext)) return true;
+    return includeConfig && CONFIG_EXTENSIONS.has(ext);
+}
+
+interface WalkContext {
+    readonly layout: ToolLayout;
+    readonly scope: KnowledgeScope;
+    readonly scopeKey: string;
+    readonly root: string;
+    readonly includeConfig: boolean;
+    readonly maxFileBytes: number;
+    readonly maxItems: number;
+    readonly items: DiscoveredKnowledgeItem[];
+    readonly skipped: SkippedKnowledgeItem[];
+    truncated: boolean;
+}
+
+/** Guards against a `..` segment or a symlinked directory escaping the root. */
+function isInsideRoot(root: string, candidate: string): boolean {
+    const relative = path.relative(root, candidate);
+    return relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative));
+}
+
+async function considerFile(
+    ctx: WalkContext,
+    absolutePath: string,
+    kind: KnowledgeKind
+): Promise<void> {
+    const relativePath = path.relative(ctx.root, absolutePath);
+    const sourceId = buildSourceId(ctx.layout.toolId, ctx.scopeKey, relativePath);
+    const name = path.basename(absolutePath);
+
+    if (isDeniedFilename(name)) {
+        ctx.skipped.push({ sourceId, reason: "excluded", detail: "denylisted filename" });
+        return;
+    }
+    if (!isReadableExtension(name, ctx.includeConfig)) {
+        ctx.skipped.push({
+            sourceId,
+            reason: "excluded",
+            detail: `unsupported extension ${path.extname(name) || "(none)"}`,
+        });
+        return;
+    }
+
+    let stats;
+    try {
+        stats = await lstat(absolutePath);
+    } catch (error) {
+        // Most layout entries are optional — a user with no `MEMORY.md` has
+        // nothing wrong with their setup. Only a real read failure (EACCES and
+        // friends) is worth reporting.
+        if (isMissing(error)) return;
+        ctx.skipped.push({ sourceId, reason: "unreadable", detail: describeError(error) });
+        return;
+    }
+
+    if (stats.isSymbolicLink()) {
+        ctx.skipped.push({ sourceId, reason: "excluded", detail: "symlink" });
+        return;
+    }
+    if (!stats.isFile()) return;
+    if (stats.size === 0) {
+        ctx.skipped.push({ sourceId, reason: "empty" });
+        return;
+    }
+    if (stats.size > ctx.maxFileBytes) {
+        ctx.skipped.push({
+            sourceId,
+            reason: "too-large",
+            detail: `${stats.size} bytes exceeds ${ctx.maxFileBytes}`,
+        });
+        return;
+    }
+    if (ctx.items.length >= ctx.maxItems) {
+        ctx.truncated = true;
+        ctx.skipped.push({ sourceId, reason: "limit-reached", detail: `maxItems=${ctx.maxItems}` });
+        return;
+    }
+
+    ctx.items.push({
+        sourceId,
+        connectorId: AGENT_KNOWLEDGE_CONNECTOR_ID,
+        title: titleFor(ctx.layout, ctx.scopeKey, relativePath),
+        kind,
+        mimeType: mimeTypeFor(absolutePath),
+        bytes: stats.size,
+        modifiedAt: stats.mtime.toISOString(),
+        location: { origin: absolutePath, relativePath: relativePath.split(path.sep).join("/") },
+        metadata: {
+            tool: ctx.layout.toolId,
+            toolLabel: ctx.layout.label,
+            scope: ctx.scope,
+            scopeKey: ctx.scopeKey,
+            kind,
+        },
+    });
+}
+
+async function walkDirectory(
+    ctx: WalkContext,
+    dir: string,
+    kind: KnowledgeKind,
+    recursive: boolean
+): Promise<void> {
+    let entries;
+    try {
+        entries = await readdir(dir, { withFileTypes: true });
+    } catch (error) {
+        if (isMissing(error)) return;
+        ctx.skipped.push({
+            sourceId: buildSourceId(
+                ctx.layout.toolId,
+                ctx.scopeKey,
+                path.relative(ctx.root, dir)
+            ),
+            reason: "unreadable",
+            detail: describeError(error),
+        });
+        return;
+    }
+
+    // Sorted so a scan of the same tree always reports in the same order —
+    // readdir order is filesystem-dependent and would make the truncation
+    // cutoff (and every test asserting on it) nondeterministic.
+    for (const entry of [...entries].sort((a, b) => a.name.localeCompare(b.name))) {
+        const child = path.join(dir, entry.name);
+        if (!isInsideRoot(ctx.root, child)) continue;
+
+        if (entry.isSymbolicLink()) {
+            ctx.skipped.push({
+                sourceId: buildSourceId(
+                    ctx.layout.toolId,
+                    ctx.scopeKey,
+                    path.relative(ctx.root, child)
+                ),
+                reason: "excluded",
+                detail: "symlink",
+            });
+            continue;
+        }
+
+        if (entry.isDirectory()) {
+            if (!recursive || isDeniedDirectory(entry.name)) continue;
+            await walkDirectory(ctx, child, kind, recursive);
+            continue;
+        }
+
+        if (entry.isFile()) {
+            await considerFile(ctx, child, kind);
+        }
+    }
+}
+
+async function scanEntry(ctx: WalkContext, entry: LayoutEntry): Promise<void> {
+    if (entry.config && !ctx.includeConfig) return;
+
+    const absolutePath = path.resolve(ctx.root, entry.path);
+    if (!isInsideRoot(ctx.root, absolutePath)) return;
+
+    if (entry.target === "file") {
+        await considerFile(ctx, absolutePath, entry.kind);
+        return;
+    }
+
+    if (entry.target === "nested") {
+        await walkNested(ctx, absolutePath, entry);
+        return;
+    }
+
+    await walkDirectory(ctx, absolutePath, entry.kind, entry.recursive ?? false);
+}
+
+/**
+ * Walk `<dir>/<child>/<entry.nested>` for each immediate child directory.
+ *
+ * Used where a knowledge folder is buried one level inside a directory whose
+ * other contents must stay untouched — `~/.claude/projects/<slug>/memory` next
+ * to that slug's session transcripts.
+ */
+async function walkNested(ctx: WalkContext, dir: string, entry: LayoutEntry): Promise<void> {
+    const nested = entry.nested;
+    if (!nested) return;
+
+    let children;
+    try {
+        children = await readdir(dir, { withFileTypes: true });
+    } catch {
+        return;
+    }
+
+    for (const child of [...children].sort((a, b) => a.name.localeCompare(b.name))) {
+        if (!child.isDirectory() || child.isSymbolicLink()) continue;
+        const target = path.join(dir, child.name, nested);
+        if (!isInsideRoot(ctx.root, target)) continue;
+        await walkDirectory(ctx, target, entry.kind, true);
+    }
+}
+
+async function directoryExists(dir: string): Promise<boolean> {
+    try {
+        const stats = await lstat(dir);
+        if (stats.isDirectory()) return true;
+        if (!stats.isSymbolicLink()) return false;
+        // A symlinked *root* is normal (`~/.claude` pointing at a dotfiles
+        // repo). Resolving it once here is safe; the walk below still refuses
+        // to follow any symlink found underneath.
+        const resolved = await realpath(dir);
+        return (await lstat(resolved)).isDirectory();
+    } catch {
+        return false;
+    }
+}
+
+async function resolveRoot(dir: string): Promise<string> {
+    try {
+        return await realpath(dir);
+    } catch {
+        return path.resolve(dir);
+    }
+}
+
+/**
+ * Discover — but do not read — every knowledge file the configured tools
+ * expose. Cheap enough to run on a page load; `collectAgentKnowledge` is the
+ * step that actually opens files.
+ */
+export async function scanAgentKnowledge(
+    options: AgentKnowledgeScanOptions = {}
+): Promise<AgentKnowledgeScan> {
+    const home = options.homeDir ?? homedir();
+    const tools = options.tools ?? TOOL_LAYOUTS.map(layout => layout.toolId);
+    const scopes = options.scopes ?? (["global", "project"] as const);
+    const includeConfig = options.includeConfig ?? false;
+    const maxFileBytes = options.maxFileBytes ?? DEFAULT_MAX_FILE_BYTES;
+    const maxItems = options.maxItems ?? DEFAULT_MAX_ITEMS;
+    const projects = (options.projects ?? []).map(normalizeProject);
+
+    const items: DiscoveredKnowledgeItem[] = [];
+    const skipped: SkippedKnowledgeItem[] = [];
+    const roots: ScannedRoot[] = [];
+    let truncated = false;
+
+    for (const toolId of tools) {
+        const layout = layoutFor(toolId);
+
+        const targets: { scope: KnowledgeScope; key: string; dir: string; entries: readonly LayoutEntry[] }[] = [];
+        if (scopes.includes("global")) {
+            targets.push({
+                scope: "global",
+                key: "global",
+                dir: path.join(home, layout.globalRoot),
+                entries: layout.globalEntries,
+            });
+        }
+        if (scopes.includes("project")) {
+            for (const project of projects) {
+                targets.push({
+                    scope: "project",
+                    key: projectKeyFor(project),
+                    dir: path.resolve(project.dir),
+                    entries: layout.projectEntries,
+                });
+            }
+        }
+
+        for (const target of targets) {
+            const exists = await directoryExists(target.dir);
+            const before = items.length;
+            if (exists) {
+                const ctx: WalkContext = {
+                    layout,
+                    scope: target.scope,
+                    scopeKey: target.key,
+                    root: await resolveRoot(target.dir),
+                    includeConfig,
+                    maxFileBytes,
+                    maxItems,
+                    items,
+                    skipped,
+                    truncated: false,
+                };
+                for (const entry of target.entries) {
+                    await scanEntry(ctx, entry);
+                }
+                truncated = truncated || ctx.truncated;
+            }
+            roots.push({
+                toolId,
+                scope: target.scope,
+                key: target.key,
+                dir: target.dir,
+                exists,
+                itemCount: items.length - before,
+            });
+        }
+    }
+
+    return { roots, items, skipped, truncated };
+}
+
+function isMissing(error: unknown): boolean {
+    return (
+        typeof error === "object" &&
+        error !== null &&
+        (error as NodeJS.ErrnoException).code === "ENOENT"
+    );
+}
+
+export function describeError(error: unknown): string {
+    return error instanceof Error ? error.message : String(error);
+}

--- a/packages/features/src/connectors/agent-knowledge/index.ts
+++ b/packages/features/src/connectors/agent-knowledge/index.ts
@@ -1,0 +1,52 @@
+/**
+ * agent-knowledge connector — Claude Code and Codex.
+ *
+ * Reads the knowledge those tools already keep on disk (instructions,
+ * subagents, slash commands, skills, memories, prompts) and hands it to a
+ * host-supplied sink for ingestion. No auth, no API, no polling: the source
+ * is the local filesystem, so a sync is immediate.
+ */
+
+export {
+    AGENT_KNOWLEDGE_CONNECTOR_ID,
+    DEFAULT_MAX_FILE_BYTES,
+    DEFAULT_MAX_ITEMS,
+    buildSourceId,
+    scanAgentKnowledge,
+    type AgentKnowledgeScan,
+    type AgentKnowledgeScanOptions,
+    type ProjectTarget,
+    type ScannedRoot,
+} from "./discover";
+
+export {
+    collectAgentKnowledge,
+    hashContent,
+    readKnowledgeItem,
+    type CollectedAgentKnowledge,
+} from "./collect";
+
+export {
+    DEFAULT_SYNC_CONCURRENCY,
+    syncAgentKnowledge,
+    type AgentKnowledgeSyncOptions,
+    type AgentKnowledgeSyncResult,
+} from "./sync";
+
+export {
+    CLAUDE_CODE_LAYOUT,
+    CODEX_LAYOUT,
+    CONFIG_EXTENSIONS,
+    DENIED_DIRECTORIES,
+    DENIED_FILENAMES,
+    KNOWLEDGE_EXTENSIONS,
+    TOOL_LAYOUTS,
+    isDeniedDirectory,
+    isDeniedFilename,
+    layoutFor,
+    type AgentToolId,
+    type KnowledgeKind,
+    type KnowledgeScope,
+    type LayoutEntry,
+    type ToolLayout,
+} from "./layout";

--- a/packages/features/src/connectors/agent-knowledge/layout.ts
+++ b/packages/features/src/connectors/agent-knowledge/layout.ts
@@ -1,0 +1,192 @@
+/**
+ * Declarative map of where Claude Code and Codex keep durable knowledge.
+ *
+ * Both tools store two very different kinds of files under the same roots:
+ * knowledge the user authored (instructions, agents, commands, skills,
+ * memories, prompts) and machine state (session transcripts, caches, OAuth
+ * tokens, sqlite journals). Only the first kind belongs in a knowledge base,
+ * so discovery is allowlist-driven: an entry here is the *only* way a file
+ * can be picked up. Anything not named below is invisible to the connector.
+ */
+
+export type AgentToolId = "claude-code" | "codex";
+
+export type KnowledgeScope = "global" | "project";
+
+export type KnowledgeKind =
+    | "instructions"
+    | "agent"
+    | "command"
+    | "skill"
+    | "memory"
+    | "prompt"
+    | "output-style"
+    | "config";
+
+/** One allowlisted location inside a root. */
+export interface LayoutEntry {
+    /** Path relative to the root. `""` is not allowed — name a file or dir. */
+    readonly path: string;
+    readonly kind: KnowledgeKind;
+    /**
+     * `file` matches exactly one path; `dir` walks it; `nested` walks
+     * `<path>/<*>/<nested>` — one fixed subdirectory of each immediate child,
+     * and nothing else in that child.
+     */
+    readonly target: "file" | "dir" | "nested";
+    /** Required for `nested`: the subdirectory to walk inside each child. */
+    readonly nested?: string;
+    /** Only meaningful for `dir` — walk nested directories too. */
+    readonly recursive?: boolean;
+    /**
+     * Config files can hold API keys and OAuth material, so they are behind
+     * the `includeConfig` option rather than on by default.
+     */
+    readonly config?: boolean;
+}
+
+export interface ToolLayout {
+    readonly toolId: AgentToolId;
+    readonly label: string;
+    /** Directory under the user's home that holds global knowledge. */
+    readonly globalRoot: string;
+    readonly globalEntries: readonly LayoutEntry[];
+    /** Entries resolved against a project directory. */
+    readonly projectEntries: readonly LayoutEntry[];
+}
+
+export const CLAUDE_CODE_LAYOUT: ToolLayout = {
+    toolId: "claude-code",
+    label: "Claude Code",
+    globalRoot: ".claude",
+    globalEntries: [
+        { path: "CLAUDE.md", kind: "instructions", target: "file" },
+        { path: "agents", kind: "agent", target: "dir", recursive: true },
+        { path: "commands", kind: "command", target: "dir", recursive: true },
+        { path: "skills", kind: "skill", target: "dir", recursive: true },
+        { path: "memory", kind: "memory", target: "dir", recursive: true },
+        { path: "MEMORY.md", kind: "memory", target: "file" },
+        { path: "output-styles", kind: "output-style", target: "dir", recursive: true },
+        // Per-project memory lives at `projects/<slug>/memory/`. The sibling
+        // `<slug>/*.jsonl` session transcripts are the reason this is a
+        // `nested` entry and not a recursive walk of `projects/`.
+        { path: "projects", kind: "memory", target: "nested", nested: "memory" },
+        { path: "settings.json", kind: "config", target: "file", config: true },
+    ],
+    projectEntries: [
+        { path: "CLAUDE.md", kind: "instructions", target: "file" },
+        { path: "CLAUDE.local.md", kind: "instructions", target: "file" },
+        { path: ".claude/CLAUDE.md", kind: "instructions", target: "file" },
+        { path: ".claude/agents", kind: "agent", target: "dir", recursive: true },
+        { path: ".claude/commands", kind: "command", target: "dir", recursive: true },
+        { path: ".claude/skills", kind: "skill", target: "dir", recursive: true },
+        { path: ".claude/memory", kind: "memory", target: "dir", recursive: true },
+        { path: ".claude/output-styles", kind: "output-style", target: "dir", recursive: true },
+        { path: ".claude/settings.json", kind: "config", target: "file", config: true },
+    ],
+};
+
+export const CODEX_LAYOUT: ToolLayout = {
+    toolId: "codex",
+    label: "Codex",
+    globalRoot: ".codex",
+    globalEntries: [
+        { path: "AGENTS.md", kind: "instructions", target: "file" },
+        { path: "instructions.md", kind: "instructions", target: "file" },
+        { path: "prompts", kind: "prompt", target: "dir", recursive: true },
+        { path: "memories", kind: "memory", target: "dir", recursive: true },
+        { path: "config.toml", kind: "config", target: "file", config: true },
+    ],
+    projectEntries: [
+        { path: "AGENTS.md", kind: "instructions", target: "file" },
+        { path: ".codex/AGENTS.md", kind: "instructions", target: "file" },
+        { path: ".codex/prompts", kind: "prompt", target: "dir", recursive: true },
+        { path: ".codex/memories", kind: "memory", target: "dir", recursive: true },
+    ],
+};
+
+export const TOOL_LAYOUTS: readonly ToolLayout[] = [CLAUDE_CODE_LAYOUT, CODEX_LAYOUT];
+
+export function layoutFor(toolId: AgentToolId): ToolLayout {
+    const layout = TOOL_LAYOUTS.find(candidate => candidate.toolId === toolId);
+    if (!layout) throw new Error(`Unknown agent tool: ${toolId}`);
+    return layout;
+}
+
+/** Text-ish extensions a knowledge file may carry. */
+export const KNOWLEDGE_EXTENSIONS: ReadonlySet<string> = new Set([
+    ".md",
+    ".markdown",
+    ".mdx",
+    ".txt",
+]);
+
+/** Extensions only readable when `includeConfig` is on. */
+export const CONFIG_EXTENSIONS: ReadonlySet<string> = new Set([
+    ".json",
+    ".toml",
+    ".yaml",
+    ".yml",
+]);
+
+/**
+ * Names that must never be read, whatever the extension says. These sit
+ * inside allowlisted roots, so the allowlist alone would not stop them.
+ */
+export const DENIED_FILENAMES: ReadonlySet<string> = new Set([
+    ".credentials.json",
+    "auth.json",
+    "credentials.json",
+    ".env",
+    ".env.local",
+    "settings.local.json",
+    "history.jsonl",
+    "id_rsa",
+    "id_ed25519",
+]);
+
+/** Filename patterns that read as secret material. */
+export const DENIED_FILENAME_PATTERNS: readonly RegExp[] = [
+    /^\.env(\..+)?$/i,
+    /\.(pem|key|p12|pfx|keystore)$/i,
+    /(^|[-_.])(secret|secrets|token|tokens|credential|credentials)([-_.]|$)/i,
+];
+
+/** Directory names never descended into, at any depth. */
+export const DENIED_DIRECTORIES: ReadonlySet<string> = new Set([
+    ".git",
+    "node_modules",
+    "__pycache__",
+    "cache",
+    "caches",
+    "logs",
+    "tmp",
+    ".tmp",
+    "sessions",
+    "archived_sessions",
+    "projects",
+    "shell-snapshots",
+    "file-history",
+    "paste-cache",
+    "downloads",
+    "backups",
+    "session-env",
+    "ipc",
+    "daemon",
+    "todos",
+    "statsig",
+    "browser",
+    "generated_images",
+    "computer-use",
+    "node_repl",
+]);
+
+export function isDeniedFilename(name: string): boolean {
+    const lower = name.toLowerCase();
+    if (DENIED_FILENAMES.has(lower)) return true;
+    return DENIED_FILENAME_PATTERNS.some(pattern => pattern.test(lower));
+}
+
+export function isDeniedDirectory(name: string): boolean {
+    return DENIED_DIRECTORIES.has(name.toLowerCase());
+}

--- a/packages/features/src/connectors/agent-knowledge/sync.ts
+++ b/packages/features/src/connectors/agent-knowledge/sync.ts
@@ -1,0 +1,133 @@
+/**
+ * Scan → read → push, in one call.
+ *
+ * The connector owns discovery, change detection and error containment; the
+ * host owns storage. `syncAgentKnowledge` never throws for a single bad file —
+ * one unreadable skill must not abort a 200-file sync — so callers always get
+ * a report describing exactly what landed.
+ */
+
+import type {
+    KnowledgeItem,
+    KnowledgeSink,
+    KnowledgeSyncReport,
+    FailedKnowledgeItem,
+    SkippedKnowledgeItem,
+    StoredKnowledgeItem,
+} from "../types";
+import { collectAgentKnowledge } from "./collect";
+import {
+    AGENT_KNOWLEDGE_CONNECTOR_ID,
+    describeError,
+    scanAgentKnowledge,
+    type AgentKnowledgeScan,
+    type AgentKnowledgeScanOptions,
+} from "./discover";
+
+export const DEFAULT_SYNC_CONCURRENCY = 4;
+
+export interface AgentKnowledgeSyncOptions extends AgentKnowledgeScanOptions {
+    readonly sink: KnowledgeSink;
+    /** Parallel `sink.store` calls. Defaults to 4. */
+    readonly concurrency?: number;
+    /** Re-upload even when the sink reports an identical content hash. */
+    readonly force?: boolean;
+    /** Clock seam for deterministic tests. */
+    readonly now?: () => Date;
+}
+
+export interface AgentKnowledgeSyncResult extends KnowledgeSyncReport {
+    readonly scan: AgentKnowledgeScan;
+    readonly truncated: boolean;
+}
+
+async function runWithConcurrency<T>(
+    tasks: readonly (() => Promise<T>)[],
+    limit: number
+): Promise<T[]> {
+    const results = new Array<T>(tasks.length);
+    let cursor = 0;
+
+    const workers = Array.from({ length: Math.max(1, Math.min(limit, tasks.length)) }, async () => {
+        while (true) {
+            const index = cursor++;
+            const task = tasks[index];
+            if (!task) return;
+            results[index] = await task();
+        }
+    });
+
+    await Promise.all(workers);
+    return results;
+}
+
+type StoreOutcome =
+    | { readonly kind: "stored"; readonly value: StoredKnowledgeItem }
+    | { readonly kind: "skipped"; readonly value: SkippedKnowledgeItem }
+    | { readonly kind: "failed"; readonly value: FailedKnowledgeItem };
+
+async function storeItem(
+    item: KnowledgeItem,
+    sink: KnowledgeSink,
+    force: boolean
+): Promise<StoreOutcome> {
+    try {
+        if (!force && sink.lastSyncedHash) {
+            const previous = await sink.lastSyncedHash(item);
+            if (previous === item.contentHash) {
+                return { kind: "skipped", value: { sourceId: item.sourceId, reason: "unchanged" } };
+            }
+        }
+        return { kind: "stored", value: await sink.store(item) };
+    } catch (error) {
+        return {
+            kind: "failed",
+            value: { sourceId: item.sourceId, error: describeError(error) },
+        };
+    }
+}
+
+/**
+ * Fetch every piece of pre-existing Claude Code / Codex knowledge on this
+ * machine and push it into the host's knowledge base.
+ */
+export async function syncAgentKnowledge(
+    options: AgentKnowledgeSyncOptions
+): Promise<AgentKnowledgeSyncResult> {
+    const { sink, concurrency, force, now, ...scanOptions } = options;
+    const clock = now ?? (() => new Date());
+    const startedAt = clock();
+
+    const scan = await scanAgentKnowledge(scanOptions);
+    const collected = await collectAgentKnowledge(scan.items);
+
+    const outcomes = await runWithConcurrency(
+        collected.items.map(item => () => storeItem(item, sink, force ?? false)),
+        concurrency ?? DEFAULT_SYNC_CONCURRENCY
+    );
+
+    const stored: StoredKnowledgeItem[] = [];
+    const skipped: SkippedKnowledgeItem[] = [...scan.skipped, ...collected.skipped];
+    const failed: FailedKnowledgeItem[] = [];
+
+    for (const outcome of outcomes) {
+        if (outcome.kind === "stored") stored.push(outcome.value);
+        else if (outcome.kind === "skipped") skipped.push(outcome.value);
+        else failed.push(outcome.value);
+    }
+
+    const finishedAt = clock();
+
+    return {
+        connectorId: AGENT_KNOWLEDGE_CONNECTOR_ID,
+        startedAt: startedAt.toISOString(),
+        finishedAt: finishedAt.toISOString(),
+        durationMs: finishedAt.getTime() - startedAt.getTime(),
+        discovered: scan.items.length,
+        stored,
+        skipped,
+        failed,
+        scan,
+        truncated: scan.truncated,
+    };
+}

--- a/packages/features/src/connectors/index.ts
+++ b/packages/features/src/connectors/index.ts
@@ -1,1 +1,2 @@
-export {};
+export * from "./types";
+export * from "./agent-knowledge";

--- a/packages/features/src/connectors/types.ts
+++ b/packages/features/src/connectors/types.ts
@@ -1,0 +1,96 @@
+/**
+ * Shared connector contract.
+ *
+ * A connector turns some external body of knowledge into a flat list of
+ * `KnowledgeItem`s that the host can push through the normal document
+ * ingestion pipeline. Connectors never talk to the database or to storage
+ * themselves — the host supplies a {@link KnowledgeSink}. That keeps the
+ * feature package free of `apps/web` imports and makes every connector
+ * testable with an in-memory sink.
+ */
+
+/** Where a connector found an item, in the connector's own vocabulary. */
+export interface KnowledgeItemLocation {
+    /** Absolute path / URL on the machine that ran the scan. Not uploaded. */
+    readonly origin: string;
+    /** Path relative to the scanned root. Stable across machines. */
+    readonly relativePath: string;
+}
+
+/**
+ * One unit of knowledge, before its contents have been read.
+ *
+ * `sourceId` is the stable identity of the item across syncs. It must not
+ * embed machine-specific data (home directory, absolute paths) because it is
+ * the basis of the host's idempotency key.
+ */
+export interface DiscoveredKnowledgeItem {
+    readonly sourceId: string;
+    readonly connectorId: string;
+    readonly title: string;
+    readonly kind: string;
+    readonly mimeType: string;
+    readonly bytes: number;
+    readonly modifiedAt: string;
+    readonly location: KnowledgeItemLocation;
+    readonly metadata: Readonly<Record<string, unknown>>;
+}
+
+/** A discovered item whose contents have been read. */
+export interface KnowledgeItem extends DiscoveredKnowledgeItem {
+    readonly content: string;
+    /** sha256 of `content`. Drives change detection. */
+    readonly contentHash: string;
+}
+
+/** An item the scan deliberately passed over, and why. */
+export interface SkippedKnowledgeItem {
+    readonly sourceId: string;
+    readonly reason: SkipReason;
+    readonly detail?: string;
+}
+
+export type SkipReason =
+    | "unchanged"
+    | "too-large"
+    | "empty"
+    | "excluded"
+    | "unreadable"
+    | "limit-reached";
+
+/**
+ * Host-supplied destination for scanned knowledge.
+ *
+ * `lastSyncedHash` lets the connector skip work that is already in the
+ * knowledge base; returning `null` (or omitting the method) makes every sync
+ * a full re-upload, which is always correct, just slower.
+ */
+export interface KnowledgeSink {
+    lastSyncedHash?(item: DiscoveredKnowledgeItem): Promise<string | null>;
+    store(item: KnowledgeItem): Promise<StoredKnowledgeItem>;
+}
+
+export interface StoredKnowledgeItem {
+    readonly sourceId: string;
+    readonly documentId: number;
+    readonly versionId: number;
+    readonly jobId: string | null;
+    /** True when the sink created a new version of an existing document. */
+    readonly revised: boolean;
+}
+
+export interface FailedKnowledgeItem {
+    readonly sourceId: string;
+    readonly error: string;
+}
+
+export interface KnowledgeSyncReport {
+    readonly connectorId: string;
+    readonly startedAt: string;
+    readonly finishedAt: string;
+    readonly durationMs: number;
+    readonly discovered: number;
+    readonly stored: readonly StoredKnowledgeItem[];
+    readonly skipped: readonly SkippedKnowledgeItem[];
+    readonly failed: readonly FailedKnowledgeItem[];
+}


### PR DESCRIPTION
Fills in the `connectors/` stub with **`agent-knowledge`**, which reads the knowledge Claude Code and Codex already keep on disk and pushes it through the existing ingestion path. No OAuth handshake and no polling loop — the source is the local filesystem, so a sync is immediate.

| Tool | Global (`~`) | Per project |
| --- | --- | --- |
| Claude Code | `.claude/CLAUDE.md`, `MEMORY.md`, `agents/`, `commands/`, `skills/`, `memory/`, `output-styles/`, `projects/<slug>/memory/` | `CLAUDE.md`, `CLAUDE.local.md`, `.claude/{agents,commands,skills,memory,output-styles}` |
| Codex | `.codex/AGENTS.md`, `instructions.md`, `prompts/`, `memories/` | `AGENTS.md`, `.codex/{AGENTS.md,prompts,memories}` |

## Shape

Connectors emit `KnowledgeItem`s and hand them to a host-supplied `KnowledgeSink`. The host owns blob storage and the document lifecycle; the connector owns discovery, change detection and error containment. That seam is why the entire scan/sync layer is testable with no database and no blob storage.

- `packages/features/src/connectors/types.ts` — the `KnowledgeSink` contract
- `.../agent-knowledge/{layout,discover,collect,sync}.ts` — allowlist, walk, read + sha256, orchestration
- `apps/web/src/server/services/agent-knowledge-connector.ts` — the sink: blob upload → `createDocumentLifecycle` → the transactional outbox, same as every other upload (ADR-003)
- `apps/web/src/app/api/connectors/agent-knowledge/route.ts` — `GET` previews (stats only), `POST` syncs

A changed file becomes a **new version of the same document**, not a duplicate. `sourceId` (`agent-knowledge://<tool>/<scope>/<path>`) carries no absolute paths, so identity survives a home directory move, and the content hash is part of the version key so a repeated sync converges instead of stacking versions.

## Security posture

This reads the **server's** filesystem, which on a shared host is not the user's filesystem. So:

- Off unless `AGENT_KNOWLEDGE_CONNECTOR_ENABLED` is set; project dirs confined to `AGENT_KNOWLEDGE_PROJECT_ROOTS`; employer/owner only.
- Discovery is **allowlist-driven** — a path not named in `layout.ts` cannot be picked up.
- Credential files (`.credentials.json`, `auth.json`, `.env*`, `*.pem`, anything matching `secret`/`token`/`credential`) are denylisted by name whatever their extension. Config files hold API keys, so they sit behind `includeConfig`, off by default.
- Symlinks are never followed; the walk cannot leave its root; `..` cannot escape the configured roots.
- Session transcripts stay unreachable. `projects/<slug>/memory/` is a `nested` layout entry that walks one fixed subdirectory rather than recursing past the `.jsonl` files beside it.
- Everything declined is reported with a reason — a sync never silently under-reports.

## Changes outside the connector

Each was found by *running* the thing, not by testing it. Separable if you'd rather they moved:

| File | Fix |
| --- | --- |
| `packages/adapters/.../source-lifecycle.ts` | `createDocumentVersionLifecycle` gains the `processingUrl` parameter the create path already had, plus `findDocumentByCreationKey` (re-exported through the core facade and the web service). The database storage backend returns relative URLs (`/api/files/12`) that the UI resolves per request but the worker, in another process, cannot fetch — without this the sync reports success and extraction dies later with `Failed to parse URL from /api/files/12`. |
| `apps/web/src/lib/rate-limiter.ts` | `unref()` the cleanup interval. Importing a rate-limited route otherwise keeps a Jest worker (or any short-lived script) alive until force-exit. |
| `apps/web/src/lib/api-utils.ts` | Annotate `createSuccessResponse`'s `status` as `number`. `HTTP_STATUS` is `as const`, so the inferred default pinned every caller to exactly `200`. |
| `docker-compose.yml` | Forward the `EMBEDDING`/`RERANK`/`NER` API base-URL **and** key pairs in `x-shared-env`. They are read as a pair, so forwarding the model alone leaves containers reporting `API key not configured for embeddings` no matter what `.env` holds. |

## Testing

- **63 connector tests** across discovery, refusals, sync, the sink, the policy and the route
- Full web Jest suite: **1204 passed, 0 failed**
- `pnpm -r typecheck` clean across all eight packages; ESLint clean; `check-core-facade` passes; `@launchstack/adapters` tests pass

Verified against the real `~/.claude` on a dev machine before the rebase: 12 files discovered, read, stored and dispatched; the worker fetched and chunked each one; a second run stored 0 and reported all 12 unchanged.

## Known gaps

- **Not re-verified end-to-end against the new outbox architecture.** The live run above predates the ADR-002…ADR-006 refactor that landed on main while this was in flight. The code is ported and every check passes, but the extract → chunk → index path through `apps/worker` has not been exercised with a real sync since. Worth a manual run before merge.
- No UI yet — the delivery surface is the API endpoint, consistent with how other verticals landed first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
